### PR TITLE
Feature/scraper mef locale

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Makes `python -m scripts.scraper_mef` work from repo root.

--- a/scripts/scraper_mef/.gitignore
+++ b/scripts/scraper_mef/.gitignore
@@ -1,5 +1,6 @@
 .tmp_downloads/
 .tmp_out_simulate/
+downloads_out/
 .checkpoint.json
 .checkpoint.json.tmp
 *.bin

--- a/scripts/scraper_mef/.gitignore
+++ b/scripts/scraper_mef/.gitignore
@@ -1,0 +1,6 @@
+.tmp_downloads/
+.tmp_out_simulate/
+.checkpoint.json
+.checkpoint.json.tmp
+*.bin
+*.pdf.tmp

--- a/scripts/scraper_mef/README.md
+++ b/scripts/scraper_mef/README.md
@@ -8,10 +8,11 @@ Modulo scraper sentenze MEF **senza upload/requeue in produzione**.
 
 - Parse righe tabella + (live) associazione `Visualizza` → stessa `<tr>` via `href`
 - Live: metadati dalla **pagina dettaglio** confrontati con la lista prima del salvataggio
-- Skip A/B/C con validazione PDF locale (size, `%PDF-`, `%%EOF`) — file corrotti non bloccano il ridownload
+- Skip A/B/C con validazione PDF locale (size, `%PDF-`, `%%EOF`, struttura `pypdf` trailer/catalogo)
+- Checkpoint `processed` salta solo se PDF locale ancora valido o cache server; altrimenti invalida e riscarica
 - Naming canonico `{Tipo}_{Codice}_{Numero}_{Anno}.pdf` (tipo reale, non sempre `Sentenza`)
-- `--max` = tetto sui **tentativi** (successi + falliti); gli skip non consumano il budget
-- Checkpoint/resume: `last_page`, `last_row_index`, `last_document`, `processed`, `failed`, `status`
+- `--max` = tetto sui **tentativi** (successi + falliti), `>= 1` (`--max 0` = errore)
+- Checkpoint/resume: `last_page`, `last_row_index` (reset su cambio pagina), `processed`, `failed`, `status`
 - Stop su HTTP 403/429 / segnali WAF (status `blocked` + checkpoint)
 - Upload **disabilitato** (stub)
 

--- a/scripts/scraper_mef/README.md
+++ b/scripts/scraper_mef/README.md
@@ -1,57 +1,60 @@
 # scraper_mef (Fase 2 — locale)
 
-Modulo scraper sentenze MEF **senza upload/requeue in produzione** finché non arriva Gate 2.
+Modulo scraper sentenze MEF **senza upload/requeue in produzione**.
+
+**Nessun pilota, upload o deploy è autorizzato in questa versione.**
+
+## Cosa è implementato
+
+- Parse righe tabella + (live) associazione `Visualizza` → stessa `<tr>` via `href`
+- Live: metadati dalla **pagina dettaglio** confrontati con la lista prima del salvataggio
+- Skip A/B/C con validazione PDF locale (size, `%PDF-`, `%%EOF`) — file corrotti non bloccano il ridownload
+- Naming canonico `{Tipo}_{Codice}_{Numero}_{Anno}.pdf` (tipo reale, non sempre `Sentenza`)
+- `--max` = tetto sui **tentativi** (successi + falliti); gli skip non consumano il budget
+- Checkpoint/resume: `last_page`, `last_row_index`, `last_document`, `processed`, `failed`, `status`
+- Stop su HTTP 403/429 / segnali WAF (status `blocked` + checkpoint)
+- Upload **disabilitato** (stub)
+
+## Cosa NON è implementato (dichiarato)
+
+| Funzione | Stato |
+|----------|--------|
+| Paginazione automatica su tutte le pagine MEF | **NON implementata** |
+| Ricerca/navigazione autonoma senza tab CDP | **NON implementata** |
+| Concorrenza multi-worker / lease | **NON implementata** (semaforo locale 1–2 stub) |
+| Upload SGAI / parsing / embedding | **NON implementato** (stub disabilitato) |
+| Admin live / heartbeat remoto | **NON in questa PR** |
+| `page_delay` tra pagine | stub presente, inutilizzato senza paginazione |
+
+## Config (niente path assoluti del PC)
+
+| Env / flag | Default |
+|------------|---------|
+| `MEF_SCRAPER_OUTPUT` / `--output-dir` | `scripts/scraper_mef/downloads_out` |
+| `MEF_SCRAPER_SERVER_CACHES` / `--server-cache` | solo `data/cache_nomi_base_local.txt` |
+| `MEF_SCRAPER_CHECKPOINT` | `.checkpoint.json` |
+| `MEF_SCRAPER_UPLOAD` | `0` |
+| `MEF_SCRAPER_MIN_PDF_BYTES` | `1000` |
 
 ## Comandi
 
 Dalla root della repo `ragflow`:
 
-### dry-run (solo skip A/B/C)
 ```powershell
-python -m scripts.scraper_mef dry-run
+python -m scripts.scraper_mef dry-run --output-dir .\scripts\scraper_mef\downloads_out
+python -m scripts.scraper_mef probe Sentenza_V70_100_2025.pdf --output-dir ...
+python -m scripts.scraper_mef run --max 1 --no-resume
+python -m scripts.scraper_mef run --live --max 1 --cdp http://127.0.0.1:9222 --output-dir ...
 ```
 
-### probe
-```powershell
-python -m scripts.scraper_mef probe Sentenza_V70_100_2025.pdf
-```
-
-### run — simulate (default, sicuro, 1 PDF sintetico)
-```powershell
-python -m scripts.scraper_mef run --max 1
-```
-Salva in `scripts/scraper_mef/.tmp_out_simulate` (non sporca `downloads_mef`).
-
-### run — live (browser già aperto + CDP)
-```powershell
-python -m scripts.scraper_mef run --live --max 1 --cdp http://127.0.0.1:9222
-```
-Richiede Edge/Opera con remote debugging e pagina risultati MEF aperta.
-
-## Limiti (punto 3)
-- download concurrency default **1** (max 2)
-- delay tra download 18–32s (env `MEF_SCRAPER_DL_DELAY_*`)
-- upload **disabilitato** (`MEF_SCRAPER_UPLOAD=0`)
-- Ctrl+C = stop pulito dopo il file corrente
-- cleanup tmp (tiene pochi file recenti)
-
-## Skip
-- `skip_local` (A) — PDF in `downloads_mef`
-- `skip_server` (B) — cache nomi / skip D:
-- `skip_embedded` — `|embedded`
-- `would_download` / `downloaded` (C)
+`--live` richiede browser con remote debugging e pagina risultati MEF già aperta.
+Su CAPTCHA / 403 / 429 ripetuti: stop, checkpoint `blocked`, nessun bypass VPN.
 
 ## Test
 
 ```powershell
 cd scripts
-python -m unittest scraper_mef.tests.test_parse_names scraper_mef.tests.test_cache_skip scraper_mef.tests.test_checkpoint
+python -m unittest discover -s scraper_mef/tests -v
 ```
 
-## Mappa corti
-
-File: `data/codici_corte.json` (usato da `portal_to_filename.py` / `names.py`).
-
-## Upload
-
-Disabilitato di default (`MEF_SCRAPER_UPLOAD=0`). Non abilitare senza autorizzazione.
+Coprono: parse/tipo, skip locale corrotto, `--max` su tentativi falliti, resume checkpoint, allineamento lista/dettaglio, PDF/HTML invalidi, 403/429, righe incomplete, duplicati.

--- a/scripts/scraper_mef/README.md
+++ b/scripts/scraper_mef/README.md
@@ -1,0 +1,57 @@
+# scraper_mef (Fase 2 — locale)
+
+Modulo scraper sentenze MEF **senza upload/requeue in produzione** finché non arriva Gate 2.
+
+## Comandi
+
+Dalla root della repo `ragflow`:
+
+### dry-run (solo skip A/B/C)
+```powershell
+python -m scripts.scraper_mef dry-run
+```
+
+### probe
+```powershell
+python -m scripts.scraper_mef probe Sentenza_V70_100_2025.pdf
+```
+
+### run — simulate (default, sicuro, 1 PDF sintetico)
+```powershell
+python -m scripts.scraper_mef run --max 1
+```
+Salva in `scripts/scraper_mef/.tmp_out_simulate` (non sporca `downloads_mef`).
+
+### run — live (browser già aperto + CDP)
+```powershell
+python -m scripts.scraper_mef run --live --max 1 --cdp http://127.0.0.1:9222
+```
+Richiede Edge/Opera con remote debugging e pagina risultati MEF aperta.
+
+## Limiti (punto 3)
+- download concurrency default **1** (max 2)
+- delay tra download 18–32s (env `MEF_SCRAPER_DL_DELAY_*`)
+- upload **disabilitato** (`MEF_SCRAPER_UPLOAD=0`)
+- Ctrl+C = stop pulito dopo il file corrente
+- cleanup tmp (tiene pochi file recenti)
+
+## Skip
+- `skip_local` (A) — PDF in `downloads_mef`
+- `skip_server` (B) — cache nomi / skip D:
+- `skip_embedded` — `|embedded`
+- `would_download` / `downloaded` (C)
+
+## Test
+
+```powershell
+cd scripts
+python -m unittest scraper_mef.tests.test_parse_names scraper_mef.tests.test_cache_skip scraper_mef.tests.test_checkpoint
+```
+
+## Mappa corti
+
+File: `data/codici_corte.json` (usato da `portal_to_filename.py` / `names.py`).
+
+## Upload
+
+Disabilitato di default (`MEF_SCRAPER_UPLOAD=0`). Non abilitare senza autorizzazione.

--- a/scripts/scraper_mef/__init__.py
+++ b/scripts/scraper_mef/__init__.py
@@ -1,0 +1,3 @@
+"""Scraper MEF locale (Fase 2) — senza upload/requeue in produzione finché Gate 2."""
+
+__version__ = "0.1.0"

--- a/scripts/scraper_mef/__main__.py
+++ b/scripts/scraper_mef/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/scripts/scraper_mef/cache.py
+++ b/scripts/scraper_mef/cache.py
@@ -1,8 +1,10 @@
-"""Skip a 3 livelli: locale (cartella PDF), server/archivio (liste nomi), embedding flag."""
+"""Skip a 3 livelli: locale (PDF valido), server/archivio (liste nomi), embedding flag."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+
+from .download import local_pdf_ok, validate_local_pdf
 
 
 def _norm_base(name: str) -> str:
@@ -10,20 +12,6 @@ def _norm_base(name: str) -> str:
     if text.lower().endswith(".pdf"):
         text = text[:-4]
     return text.lower()
-
-
-def _read_nome_keys(path: Path) -> set[str]:
-    keys: set[str] = set()
-    if not path.exists():
-        return keys
-    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
-        key = line.strip()
-        if not key or key.startswith("#"):
-            continue
-        if "|embedded" in key.lower():
-            key = key.split("|", 1)[0].strip()
-        keys.add(_norm_base(key))
-    return keys
 
 
 @dataclass
@@ -38,10 +26,11 @@ class SkipDecision:
 
 class SkipIndex:
     """
-    Ordine di valutazione (come download_mef_2025):
-      1) locale  → PDF già in output_dir (downloads_mef)
-      2) server  → nome in cache_nomi_base / mef_skip_from_d_*
+    Ordine di valutazione:
+      1) locale  → PDF valido già in output_dir (size/firma/EOF)
+      2) server  → nome in cache / |embedded
       3) altrimenti → would_download
+    File locali corrotti/vuoti/HTML non fanno skip_local (consentono ridownload).
     """
 
     def __init__(
@@ -50,10 +39,14 @@ class SkipIndex:
         output_dir: Path | None = None,
         server_cache_files: list[Path] | None = None,
         embedded_files: list[Path] | None = None,
+        min_pdf_bytes: int = 1000,
+        max_pdf_bytes: int = 80_000_000,
     ) -> None:
         self.output_dir = output_dir
         self.server_cache_files = server_cache_files or []
         self.embedded_files = embedded_files or []
+        self.min_pdf_bytes = int(min_pdf_bytes)
+        self.max_pdf_bytes = int(max_pdf_bytes)
         self.server_keys: set[str] = set()
         self.embedded_keys: set[str] = set()
         self.sources: list[str] = []
@@ -98,9 +91,23 @@ class SkipIndex:
             return None
         return self.output_dir / f"{nome_base}.pdf"
 
+    def local_errors(self, nome_base: str) -> list[str]:
+        path = self.local_path(nome_base)
+        if not path:
+            return ["no output_dir"]
+        if not path.exists():
+            return ["non esiste"]
+        return validate_local_pdf(
+            path, min_bytes=self.min_pdf_bytes, max_bytes=self.max_pdf_bytes
+        )
+
     def is_local(self, nome_base: str) -> bool:
         path = self.local_path(nome_base)
-        return bool(path and path.exists())
+        if not path or not path.exists():
+            return False
+        return local_pdf_ok(
+            path, min_bytes=self.min_pdf_bytes, max_bytes=self.max_pdf_bytes
+        )
 
     def is_server(self, nome_base: str) -> bool:
         return _norm_base(nome_base) in self.server_keys
@@ -110,11 +117,20 @@ class SkipIndex:
 
     def decide(self, nome_base: str) -> SkipDecision:
         base = nome_base if not nome_base.lower().endswith(".pdf") else nome_base[:-4]
-        if self.is_local(base):
+        path = self.local_path(base)
+        if path and path.exists():
+            errs = self.local_errors(base)
+            if not errs:
+                return SkipDecision(
+                    action="skip_local",
+                    layer="A_locale",
+                    detail=str(path),
+                )
+            # file presente ma invalido → non skip; segnala per ridownload
             return SkipDecision(
-                action="skip_local",
-                layer="A_locale",
-                detail=str(self.local_path(base)),
+                action="would_download",
+                layer="A_locale_corrupt",
+                detail=f"locale invalido ({'; '.join(errs)}): {path}",
             )
         if self.is_embedded(base):
             return SkipDecision(

--- a/scripts/scraper_mef/cache.py
+++ b/scripts/scraper_mef/cache.py
@@ -1,0 +1,147 @@
+"""Skip a 3 livelli: locale (cartella PDF), server/archivio (liste nomi), embedding flag."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _norm_base(name: str) -> str:
+    text = (name or "").strip()
+    if text.lower().endswith(".pdf"):
+        text = text[:-4]
+    return text.lower()
+
+
+def _read_nome_keys(path: Path) -> set[str]:
+    keys: set[str] = set()
+    if not path.exists():
+        return keys
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        key = line.strip()
+        if not key or key.startswith("#"):
+            continue
+        if "|embedded" in key.lower():
+            key = key.split("|", 1)[0].strip()
+        keys.add(_norm_base(key))
+    return keys
+
+
+@dataclass
+class SkipDecision:
+    action: str
+    layer: str
+    detail: str
+
+    def to_dict(self) -> dict:
+        return {"action": self.action, "layer": self.layer, "detail": self.detail}
+
+
+class SkipIndex:
+    """
+    Ordine di valutazione (come download_mef_2025):
+      1) locale  → PDF già in output_dir (downloads_mef)
+      2) server  → nome in cache_nomi_base / mef_skip_from_d_*
+      3) altrimenti → would_download
+    """
+
+    def __init__(
+        self,
+        *,
+        output_dir: Path | None = None,
+        server_cache_files: list[Path] | None = None,
+        embedded_files: list[Path] | None = None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.server_cache_files = server_cache_files or []
+        self.embedded_files = embedded_files or []
+        self.server_keys: set[str] = set()
+        self.embedded_keys: set[str] = set()
+        self.sources: list[str] = []
+        self.reload()
+
+    def reload(self) -> None:
+        self.server_keys.clear()
+        self.embedded_keys.clear()
+        self.sources = []
+        all_files = list(self.server_cache_files) + list(self.embedded_files)
+        seen_files: set[str] = set()
+        for path in all_files:
+            keyp = str(path)
+            if keyp in seen_files:
+                continue
+            seen_files.add(keyp)
+            if not path.exists():
+                self.sources.append(f"missing:{path}")
+                continue
+            n_server = 0
+            n_emb = 0
+            for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+                raw = line.strip()
+                if not raw or raw.startswith("#"):
+                    continue
+                if "|embedded" in raw.lower():
+                    base = _norm_base(raw.split("|", 1)[0])
+                    self.embedded_keys.add(base)
+                    self.server_keys.add(base)
+                    n_emb += 1
+                    n_server += 1
+                else:
+                    self.server_keys.add(_norm_base(raw))
+                    n_server += 1
+            self.sources.append(f"cache:{path.name} server={n_server} embedded={n_emb}")
+
+        if self.output_dir:
+            self.sources.append(f"local_dir:{self.output_dir}")
+
+    def local_path(self, nome_base: str) -> Path | None:
+        if not self.output_dir:
+            return None
+        return self.output_dir / f"{nome_base}.pdf"
+
+    def is_local(self, nome_base: str) -> bool:
+        path = self.local_path(nome_base)
+        return bool(path and path.exists())
+
+    def is_server(self, nome_base: str) -> bool:
+        return _norm_base(nome_base) in self.server_keys
+
+    def is_embedded(self, nome_base: str) -> bool:
+        return _norm_base(nome_base) in self.embedded_keys
+
+    def decide(self, nome_base: str) -> SkipDecision:
+        base = nome_base if not nome_base.lower().endswith(".pdf") else nome_base[:-4]
+        if self.is_local(base):
+            return SkipDecision(
+                action="skip_local",
+                layer="A_locale",
+                detail=str(self.local_path(base)),
+            )
+        if self.is_embedded(base):
+            return SkipDecision(
+                action="skip_embedded",
+                layer="B_server_embedded",
+                detail="presente in lista |embedded",
+            )
+        if self.is_server(base):
+            return SkipDecision(
+                action="skip_server",
+                layer="B_server_or_D",
+                detail="presente in cache nomi / skip D:",
+            )
+        return SkipDecision(
+            action="would_download",
+            layer="C_manca",
+            detail="non in locale né in cache server/D:",
+        )
+
+
+# Retrocompatibilità col dry-run precedente
+class NameCache(SkipIndex):
+    def __init__(self, keys_path: Path) -> None:
+        super().__init__(server_cache_files=[keys_path], embedded_files=[keys_path])
+
+    def has(self, nome_base: str) -> bool:
+        return self.is_server(nome_base)
+
+    def should_skip(self, nome_base: str) -> bool:
+        return self.is_embedded(nome_base)

--- a/scripts/scraper_mef/checkpoint.py
+++ b/scripts/scraper_mef/checkpoint.py
@@ -1,0 +1,41 @@
+"""Checkpoint atomico per resume dopo crash."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+class Checkpoint:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.data: dict[str, Any] = {
+            "version": 1,
+            "last_page": 0,
+            "processed": [],
+            "last_nome_base": None,
+        }
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            return
+        self.data = json.loads(self.path.read_text(encoding="utf-8"))
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(self.data, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    def mark_processed(self, nome_base: str) -> None:
+        processed = self.data.setdefault("processed", [])
+        if nome_base not in processed:
+            processed.append(nome_base)
+        self.data["last_nome_base"] = nome_base
+        self.save()
+
+    def set_page(self, page: int) -> None:
+        self.data["last_page"] = int(page)
+        self.save()

--- a/scripts/scraper_mef/checkpoint.py
+++ b/scripts/scraper_mef/checkpoint.py
@@ -66,6 +66,36 @@ class Checkpoint:
             self.data["last_row_index"] = int(row_index)
         self.save()
 
+    def sync_page(self, page: int) -> None:
+        """
+        Aggiorna last_page. Se la pagina cambia rispetto al checkpoint,
+        azzera last_row_index (altrimenti le prime righe della nuova pagina
+        verrebbero saltate).
+        """
+        page = int(page)
+        prev = int(self.data.get("last_page") or 0)
+        if prev != 0 and prev != page:
+            self.data["last_row_index"] = 0
+        self.data["last_page"] = page
+        self.save()
+
+    def unmark_processed(self, nome_base: str) -> None:
+        processed = self.data.setdefault("processed", [])
+        if nome_base in processed:
+            processed.remove(nome_base)
+            self.save()
+
+    def unmark_failed(self, nome_base: str) -> None:
+        failed = self.data.setdefault("failed", [])
+        if nome_base in failed:
+            failed.remove(nome_base)
+            self.save()
+
+    def invalidate_done(self, nome_base: str) -> None:
+        """Rimuove processed/failed per consentire ridownload."""
+        self.unmark_processed(nome_base)
+        self.unmark_failed(nome_base)
+
     def mark_processed(self, nome_base: str, *, page: int | None = None, row_index: int | None = None) -> None:
         processed = self.data.setdefault("processed", [])
         if nome_base not in processed:

--- a/scripts/scraper_mef/checkpoint.py
+++ b/scripts/scraper_mef/checkpoint.py
@@ -1,4 +1,4 @@
-"""Checkpoint atomico per resume dopo crash."""
+"""Checkpoint atomico per resume reale (pagina / riga / documento)."""
 from __future__ import annotations
 
 import json
@@ -8,20 +8,44 @@ from typing import Any
 
 
 class Checkpoint:
+    """
+    Stato ripresa:
+      - last_page: pagina risultati (1-based; 0 = non impostata)
+      - last_row_index: prossima riga da processare sulla pagina corrente (0-based)
+      - last_nome_base / last_document: ultimo documento toccato
+      - processed: nomiBase già gestiti con successo (skip su resume)
+      - failed: nomiBase con tentativo fallito (non ritentare nella stessa run/resume)
+      - status: idle|running|stopped|blocked|error|completed
+    """
+
     def __init__(self, path: Path) -> None:
         self.path = path
         self.data: dict[str, Any] = {
-            "version": 1,
+            "version": 2,
             "last_page": 0,
-            "processed": [],
+            "last_row_index": 0,
             "last_nome_base": None,
+            "last_document": None,
+            "processed": [],
+            "failed": [],
+            "status": "idle",
+            "block_reason": None,
         }
         self.load()
 
     def load(self) -> None:
         if not self.path.exists():
             return
-        self.data = json.loads(self.path.read_text(encoding="utf-8"))
+        loaded = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            return
+        self.data.update(loaded)
+        self.data.setdefault("processed", [])
+        self.data.setdefault("failed", [])
+        self.data.setdefault("last_row_index", 0)
+        self.data.setdefault("last_page", 0)
+        self.data.setdefault("status", "idle")
+        self.data.setdefault("version", 2)
 
     def save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -29,13 +53,59 @@ class Checkpoint:
         tmp.write_text(json.dumps(self.data, ensure_ascii=False, indent=2), encoding="utf-8")
         os.replace(tmp, self.path)
 
-    def mark_processed(self, nome_base: str) -> None:
+    def set_status(self, status: str, *, block_reason: str | None = None) -> None:
+        self.data["status"] = status
+        if block_reason is not None:
+            self.data["block_reason"] = block_reason
+        self.save()
+
+    def set_position(self, *, page: int | None = None, row_index: int | None = None) -> None:
+        if page is not None:
+            self.data["last_page"] = int(page)
+        if row_index is not None:
+            self.data["last_row_index"] = int(row_index)
+        self.save()
+
+    def mark_processed(self, nome_base: str, *, page: int | None = None, row_index: int | None = None) -> None:
         processed = self.data.setdefault("processed", [])
         if nome_base not in processed:
             processed.append(nome_base)
+        failed = self.data.setdefault("failed", [])
+        if nome_base in failed:
+            failed.remove(nome_base)
         self.data["last_nome_base"] = nome_base
+        self.data["last_document"] = nome_base
+        if page is not None:
+            self.data["last_page"] = int(page)
+        if row_index is not None:
+            self.data["last_row_index"] = int(row_index)
         self.save()
 
-    def set_page(self, page: int) -> None:
-        self.data["last_page"] = int(page)
+    def mark_failed(self, nome_base: str, *, page: int | None = None, row_index: int | None = None) -> None:
+        failed = self.data.setdefault("failed", [])
+        if nome_base and nome_base not in failed:
+            failed.append(nome_base)
+        self.data["last_nome_base"] = nome_base
+        self.data["last_document"] = nome_base
+        if page is not None:
+            self.data["last_page"] = int(page)
+        if row_index is not None:
+            self.data["last_row_index"] = int(row_index)
         self.save()
+
+    def is_done(self, nome_base: str) -> bool:
+        if not nome_base:
+            return False
+        return nome_base in self.data.get("processed", []) or nome_base in self.data.get(
+            "failed", []
+        )
+
+    def should_skip_row(self, row_index: int, nome_base: str | None) -> bool:
+        """True se già oltre questa riga o documento già processato/fallito."""
+        if nome_base and self.is_done(nome_base):
+            return True
+        last = int(self.data.get("last_row_index") or 0)
+        # last_row_index = prossima riga da fare: salta indici minori
+        if nome_base is None and row_index < last:
+            return True
+        return False

--- a/scripts/scraper_mef/cli.py
+++ b/scripts/scraper_mef/cli.py
@@ -1,0 +1,206 @@
+"""CLI scraper MEF locale."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .cache import SkipIndex
+from .client import MefClient
+from .config import Config, ROOT
+from .logging_utils import setup_logger
+from .metrics import Metrics
+from .parse import iter_validated
+from .runner import run_scraper
+
+log = setup_logger()
+
+
+def _build_index(cfg: Config, args: argparse.Namespace) -> SkipIndex:
+    output_dir = Path(args.output_dir) if args.output_dir else cfg.output_dir
+    server_files: list[Path] = []
+    if getattr(args, "server_cache", None):
+        server_files.extend(Path(p) for p in args.server_cache)
+    if not server_files:
+        server_files.extend(cfg.default_server_caches())
+    uniq: list[Path] = []
+    seen: set[str] = set()
+    for p in server_files:
+        key = str(p.resolve()) if p.exists() else str(p)
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(p)
+    return SkipIndex(output_dir=output_dir, server_cache_files=uniq, embedded_files=uniq)
+
+
+def cmd_dry_run(fixture: Path, cfg: Config, args: argparse.Namespace) -> int:
+    if not fixture.exists():
+        log.error("Fixture non trovata: %s", fixture)
+        return 2
+
+    index = _build_index(cfg, args)
+    rows = MefClient().rows_from_fixture(fixture)
+    metrics = Metrics(discovered=len(rows))
+    results = []
+    for row, meta, errors in iter_validated(rows):
+        if errors:
+            metrics.skipped_invalid += 1
+            results.append({"action": "skip_invalid", "errors": errors, "row": row.__dict__})
+            continue
+        decision = index.decide(meta["nomeBase"])
+        if decision.action == "skip_local":
+            metrics.skipped_local += 1
+        elif decision.action == "skip_server":
+            metrics.skipped_server += 1
+        elif decision.action == "skip_embedded":
+            metrics.skipped_embedded += 1
+        else:
+            metrics.would_download += 1
+        results.append(
+            {
+                **decision.to_dict(),
+                "nomeFile": meta["nomeFile"],
+                "nomeBase": meta["nomeBase"],
+                "codice": meta["codice"],
+            }
+        )
+    print(
+        json.dumps(
+            {
+                "sources": index.sources,
+                "output_dir": str(index.output_dir),
+                "metrics": metrics.as_dict(),
+                "items": results,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_probe(nome: str, cfg: Config, args: argparse.Namespace) -> int:
+    index = _build_index(cfg, args)
+    base = nome[:-4] if nome.lower().endswith(".pdf") else nome
+    decision = index.decide(base)
+    print(
+        json.dumps(
+            {
+                "nomeBase": base,
+                "local_exists": index.is_local(base),
+                "server_known": index.is_server(base),
+                "embedded_known": index.is_embedded(base),
+                **decision.to_dict(),
+                "output_dir": str(index.output_dir),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_run(cfg: Config, args: argparse.Namespace) -> int:
+    mode = "live" if args.live else "simulate"
+    fixture = args.fixture
+    if mode == "simulate":
+        output_dir = Path(args.output_dir) if args.output_dir else (ROOT / ".tmp_out_simulate")
+    else:
+        output_dir = Path(args.output_dir) if args.output_dir else cfg.output_dir
+
+    server_caches = [Path(p) for p in (args.server_cache or [])]
+    # punto 3: forza concorrenza <=2, default 1 da config
+    if args.concurrency is not None:
+        cfg.max_download_concurrency = max(1, min(2, int(args.concurrency)))
+
+    return run_scraper(
+        cfg=cfg,
+        mode=mode,
+        max_downloads=args.max,
+        fixture=fixture,
+        output_dir=output_dir,
+        server_caches=server_caches,
+        cdp_url=args.cdp,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scraper MEF locale (Fase 2)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    def add_skip_args(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--output-dir", type=Path, default=None)
+        p.add_argument("--server-cache", action="append", default=[])
+
+    p_dry = sub.add_parser("dry-run", help="Solo skip A/B/C, nessun download")
+    p_dry.add_argument(
+        "--fixture",
+        type=Path,
+        default=ROOT / "fixtures" / "sample_rows.html",
+    )
+    add_skip_args(p_dry)
+
+    p_probe = sub.add_parser("probe", help="Skip per un singolo nome")
+    p_probe.add_argument("nome")
+    add_skip_args(p_probe)
+
+    p_run = sub.add_parser(
+        "run",
+        help="Download limitato con skip A/B/C (default: --simulate)",
+    )
+    p_run.add_argument("--max", type=int, default=1, help="Max PDF da scaricare (default 1)")
+    p_run.add_argument(
+        "--simulate",
+        action="store_true",
+        default=True,
+        help="PDF sintetico da fixture (default, sicuro, no portale)",
+    )
+    p_run.add_argument(
+        "--live",
+        action="store_true",
+        help="Download reale via CDP (browser già aperto sulla lista MEF)",
+    )
+    p_run.add_argument(
+        "--fixture",
+        type=Path,
+        default=ROOT / "fixtures" / "sample_rows.html",
+    )
+    p_run.add_argument(
+        "--cdp",
+        default="http://127.0.0.1:9222",
+        help="URL CDP per --live",
+    )
+    p_run.add_argument(
+        "--concurrency",
+        type=int,
+        default=None,
+        help="Download concorrenti (1–2, default da env/config=1)",
+    )
+    add_skip_args(p_run)
+
+    args = parser.parse_args(argv)
+    cfg = Config()
+
+    # se --live, spegni simulate
+    if getattr(args, "live", False):
+        args.simulate = False
+
+    if args.cmd == "dry-run":
+        if args.output_dir is None:
+            args.output_dir = cfg.output_dir
+        return cmd_dry_run(args.fixture, cfg, args)
+    if args.cmd == "probe":
+        if args.output_dir is None:
+            args.output_dir = cfg.output_dir
+        return cmd_probe(args.nome, cfg, args)
+    if args.cmd == "run":
+        return cmd_run(cfg, args)
+
+    parser.error(f"comando sconosciuto: {args.cmd}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scraper_mef/cli.py
+++ b/scripts/scraper_mef/cli.py
@@ -32,7 +32,13 @@ def _build_index(cfg: Config, args: argparse.Namespace) -> SkipIndex:
             continue
         seen.add(key)
         uniq.append(p)
-    return SkipIndex(output_dir=output_dir, server_cache_files=uniq, embedded_files=uniq)
+    return SkipIndex(
+        output_dir=output_dir,
+        server_cache_files=uniq,
+        embedded_files=uniq,
+        min_pdf_bytes=cfg.min_pdf_bytes,
+        max_pdf_bytes=cfg.max_pdf_bytes,
+    )
 
 
 def cmd_dry_run(fixture: Path, cfg: Config, args: argparse.Namespace) -> int:
@@ -64,6 +70,7 @@ def cmd_dry_run(fixture: Path, cfg: Config, args: argparse.Namespace) -> int:
                 "nomeFile": meta["nomeFile"],
                 "nomeBase": meta["nomeBase"],
                 "codice": meta["codice"],
+                "tipo": meta.get("tipo"),
             }
         )
     print(
@@ -89,7 +96,9 @@ def cmd_probe(nome: str, cfg: Config, args: argparse.Namespace) -> int:
         json.dumps(
             {
                 "nomeBase": base,
-                "local_exists": index.is_local(base),
+                "local_exists": bool(index.local_path(base) and index.local_path(base).exists()),
+                "local_valid": index.is_local(base),
+                "local_errors": index.local_errors(base) if index.local_path(base) else [],
                 "server_known": index.is_server(base),
                 "embedded_known": index.is_embedded(base),
                 **decision.to_dict(),
@@ -111,7 +120,6 @@ def cmd_run(cfg: Config, args: argparse.Namespace) -> int:
         output_dir = Path(args.output_dir) if args.output_dir else cfg.output_dir
 
     server_caches = [Path(p) for p in (args.server_cache or [])]
-    # punto 3: forza concorrenza <=2, default 1 da config
     if args.concurrency is not None:
         cfg.max_download_concurrency = max(1, min(2, int(args.concurrency)))
 
@@ -123,6 +131,7 @@ def cmd_run(cfg: Config, args: argparse.Namespace) -> int:
         output_dir=output_dir,
         server_caches=server_caches,
         cdp_url=args.cdp,
+        resume=not args.no_resume,
     )
 
 
@@ -132,7 +141,12 @@ def main(argv: list[str] | None = None) -> int:
 
     def add_skip_args(p: argparse.ArgumentParser) -> None:
         p.add_argument("--output-dir", type=Path, default=None)
-        p.add_argument("--server-cache", action="append", default=[])
+        p.add_argument(
+            "--server-cache",
+            action="append",
+            default=[],
+            help="File cache nomi (ripetibile). Oppure env MEF_SCRAPER_SERVER_CACHES",
+        )
 
     p_dry = sub.add_parser("dry-run", help="Solo skip A/B/C, nessun download")
     p_dry.add_argument(
@@ -150,7 +164,12 @@ def main(argv: list[str] | None = None) -> int:
         "run",
         help="Download limitato con skip A/B/C (default: --simulate)",
     )
-    p_run.add_argument("--max", type=int, default=1, help="Max PDF da scaricare (default 1)")
+    p_run.add_argument(
+        "--max",
+        type=int,
+        default=1,
+        help="Max TENTATIVI download (successi + falliti). Default 1. Gli skip non contano.",
+    )
     p_run.add_argument(
         "--simulate",
         action="store_true",
@@ -176,14 +195,18 @@ def main(argv: list[str] | None = None) -> int:
         "--concurrency",
         type=int,
         default=None,
-        help="Download concorrenti (1–2, default da env/config=1)",
+        help="Download concorrenti (1–2 stub, default 1). Non è multi-worker.",
+    )
+    p_run.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Ignora checkpoint (azzera posizione/processed/failed di questa sessione)",
     )
     add_skip_args(p_run)
 
     args = parser.parse_args(argv)
     cfg = Config()
 
-    # se --live, spegni simulate
     if getattr(args, "live", False):
         args.simulate = False
 

--- a/scripts/scraper_mef/cli.py
+++ b/scripts/scraper_mef/cli.py
@@ -113,6 +113,9 @@ def cmd_probe(nome: str, cfg: Config, args: argparse.Namespace) -> int:
 
 def cmd_run(cfg: Config, args: argparse.Namespace) -> int:
     mode = "live" if args.live else "simulate"
+    if int(args.max) < 1:
+        log.error("--max deve essere >= 1 (ricevuto %s); nessun tentativo", args.max)
+        return 2
     fixture = args.fixture
     if mode == "simulate":
         output_dir = Path(args.output_dir) if args.output_dir else (ROOT / ".tmp_out_simulate")
@@ -168,7 +171,7 @@ def main(argv: list[str] | None = None) -> int:
         "--max",
         type=int,
         default=1,
-        help="Max TENTATIVI download (successi + falliti). Default 1. Gli skip non contano.",
+        help="Max TENTATIVI download (successi + falliti), >= 1. Default 1. --max 0 = errore.",
     )
     p_run.add_argument(
         "--simulate",

--- a/scripts/scraper_mef/client.py
+++ b/scripts/scraper_mef/client.py
@@ -1,0 +1,145 @@
+"""
+Client portale MEF.
+
+- fixture: HTML locale
+- simulate: nessun browser (PDF sintetico)
+- live: Playwright via CDP su browser già aperto (stesso approccio anti-Akamai)
+"""
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from .parse import PortalRow, parse_table_html
+
+SITE_ORIGIN = "https://bancadatigiurisprudenza.giustiziatributaria.gov.it"
+VISUALIZZA_SELECTOR = 'a[title^="Visualizza provvedimento"]'
+DETTAGLIO_SCARICA_BTN = 'button[title="Scarica il pdf del provvedimento"]'
+
+
+class MefClient:
+    def rows_from_fixture(self, html_path: Path) -> list[PortalRow]:
+        html = html_path.read_text(encoding="utf-8")
+        return parse_table_html(html)
+
+    def rows_from_html(self, html: str) -> list[PortalRow]:
+        return parse_table_html(html)
+
+
+class LiveMefClient:
+    """Si collega a Edge/Chromium già avviato con remote debugging."""
+
+    def __init__(self, cdp_url: str = "http://127.0.0.1:9222") -> None:
+        self.cdp_url = cdp_url
+        self._pw = None
+        self._browser = None
+        self.page = None
+
+    def __enter__(self) -> "LiveMefClient":
+        from playwright.sync_api import sync_playwright
+
+        self._pw = sync_playwright().start()
+        self._browser = self._pw.chromium.connect_over_cdp(self.cdp_url)
+        contexts = self._browser.contexts
+        if not contexts:
+            raise RuntimeError("Nessun context CDP — avvia Edge/Opera con remote debugging")
+        pages = contexts[0].pages
+        if not pages:
+            raise RuntimeError("Nessuna tab aperta nel browser CDP")
+        # preferisci tab con risultati MEF
+        chosen = pages[0]
+        for p in pages:
+            try:
+                if "giustiziatributaria" in (p.url or ""):
+                    chosen = p
+                    break
+            except Exception:
+                continue
+        self.page = chosen
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        # Non chiudere il browser dell'utente: solo disconnect Playwright
+        try:
+            if self._browser:
+                self._browser.close()
+        except Exception:
+            pass
+        try:
+            if self._pw:
+                self._pw.stop()
+        except Exception:
+            pass
+
+    def current_rows(self) -> list[PortalRow]:
+        assert self.page is not None
+        html = self.page.content()
+        rows = parse_table_html(html)
+        # arricchisci title dai link Visualizza se possibile
+        try:
+            titles = self.page.eval_on_selector_all(
+                VISUALIZZA_SELECTOR,
+                "els => els.map(e => e.getAttribute('title') || '')",
+            )
+            for i, row in enumerate(rows):
+                if i < len(titles) and titles[i]:
+                    row.title = titles[i]
+        except Exception:
+            pass
+        return rows
+
+    def download_row_pdf(self, row_index: int, tmp_path: Path) -> bytes:
+        """Apre dettaglio della riga N e scarica il PDF."""
+        assert self.page is not None
+        page = self.page
+        lista_url = page.url
+        tmp_path.parent.mkdir(parents=True, exist_ok=True)
+        vis = page.locator(VISUALIZZA_SELECTOR).nth(row_index)
+        href = vis.get_attribute("href") or ""
+        if href.startswith("/"):
+            href = f"{SITE_ORIGIN}{href}"
+        if href.startswith("http"):
+            page.goto(href, timeout=60000)
+        else:
+            vis.click()
+        page.wait_for_url("**/ricerca/dettaglio/**", timeout=60000)
+        page.wait_for_selector(DETTAGLIO_SCARICA_BTN, timeout=30000)
+        try:
+            with page.expect_download(timeout=90000) as download_info:
+                page.locator(DETTAGLIO_SCARICA_BTN).click()
+            download_info.value.save_as(str(tmp_path))
+        except Exception:
+            pdf_url = page.evaluate(
+                """() => {
+                    const btn = document.querySelector('button[title="Scarica il pdf del provvedimento"]');
+                    return btn ? (btn.getAttribute('data-url') || btn.dataset?.url || '') : '';
+                }"""
+            )
+            if not pdf_url:
+                onclick = page.locator(DETTAGLIO_SCARICA_BTN).get_attribute("onclick") or ""
+                m = re.search(r"https?://[^'\"\\s]+\.pdf", onclick, re.I)
+                pdf_url = m.group(0) if m else ""
+            if pdf_url:
+                if pdf_url.startswith("/"):
+                    pdf_url = f"{SITE_ORIGIN}{pdf_url}"
+                resp = page.context.request.get(pdf_url, timeout=90000)
+                if not resp.ok:
+                    raise RuntimeError(f"HTTP {resp.status} su PDF")
+                tmp_path.write_bytes(resp.body())
+            else:
+                raise
+        finally:
+            try:
+                if page.url != lista_url:
+                    page.goto(lista_url, timeout=60000)
+                    page.wait_for_selector(VISUALIZZA_SELECTOR, timeout=45000)
+            except Exception:
+                pass
+            time.sleep(0.5)
+
+        data = tmp_path.read_bytes()
+        if not data.startswith(b"%PDF"):
+            raise RuntimeError("download non è un PDF valido")
+        return data

--- a/scripts/scraper_mef/client.py
+++ b/scripts/scraper_mef/client.py
@@ -3,7 +3,10 @@ Client portale MEF.
 
 - fixture: HTML locale
 - simulate: nessun browser (PDF sintetico)
-- live: Playwright via CDP su browser già aperto (stesso approccio anti-Akamai)
+- live: Playwright via CDP su browser già aperto
+
+Live: ogni PDF è legato al proprio link Visualizza (href) e ai metadati
+della pagina dettaglio — mai all'indice tra sole righe "valide" filtrate.
 """
 from __future__ import annotations
 
@@ -12,11 +15,54 @@ import time
 from pathlib import Path
 from typing import Any
 
-from .parse import PortalRow, parse_table_html
+from .parse import PortalRow, parse_detail_text, parse_table_html, rows_from_link_dicts
 
 SITE_ORIGIN = "https://bancadatigiurisprudenza.giustiziatributaria.gov.it"
 VISUALIZZA_SELECTOR = 'a[title^="Visualizza provvedimento"]'
 DETTAGLIO_SCARICA_BTN = 'button[title="Scarica il pdf del provvedimento"]'
+
+# JS: associa ogni Visualizza alla sua <tr> (non a un array filtrato a parte)
+EXTRACT_LINKED_ROWS_JS = """
+() => {
+    const links = [...document.querySelectorAll('a[title^="Visualizza provvedimento"]')];
+    const headers = [...document.querySelectorAll("table thead th")]
+        .map(th => th.innerText.trim().toLowerCase());
+    const idx = {
+        tipo: headers.findIndex(h => h === "tipo"),
+        numdec: headers.findIndex(h => h.includes("numero")),
+        anno: headers.findIndex(h => h === "anno"),
+        autorita: headers.findIndex(h => h.includes("autorit")),
+    };
+    const pick = (cells, key) => {
+        const i = idx[key];
+        return i >= 0 && cells[i] ? cells[i].trim() : null;
+    };
+    return links.map((link, i) => {
+        const row = link.closest("tr");
+        const cells = row ? [...row.querySelectorAll("td")].map(td => td.innerText.trim()) : [];
+        return {
+            row_index: i,
+            href: link.getAttribute("href") || "",
+            title: link.getAttribute("title") || "",
+            tipo: pick(cells, "tipo") || (cells[0] || "Sentenza"),
+            numero: pick(cells, "numdec") || (cells[1] || ""),
+            anno: pick(cells, "anno") || (cells[2] || ""),
+            corte: pick(cells, "autorita") || (cells[3] || ""),
+            cells,
+        };
+    });
+}
+"""
+
+
+class MefHttpError(Exception):
+    def __init__(self, status: int, message: str = "") -> None:
+        self.status = int(status)
+        super().__init__(message or f"HTTP {status}")
+
+
+class MefBlockedError(MefHttpError):
+    """403/429 o segnali di blocco WAF/CAPTCHA — stop + checkpoint."""
 
 
 class MefClient:
@@ -48,7 +94,6 @@ class LiveMefClient:
         pages = contexts[0].pages
         if not pages:
             raise RuntimeError("Nessuna tab aperta nel browser CDP")
-        # preferisci tab con risultati MEF
         chosen = pages[0]
         for p in pages:
             try:
@@ -61,7 +106,6 @@ class LiveMefClient:
         return self
 
     def __exit__(self, *exc: Any) -> None:
-        # Non chiudere il browser dell'utente: solo disconnect Playwright
         try:
             if self._browser:
                 self._browser.close()
@@ -73,39 +117,87 @@ class LiveMefClient:
         except Exception:
             pass
 
-    def current_rows(self) -> list[PortalRow]:
+    def current_page_number(self) -> int:
         assert self.page is not None
-        html = self.page.content()
-        rows = parse_table_html(html)
-        # arricchisci title dai link Visualizza se possibile
         try:
-            titles = self.page.eval_on_selector_all(
-                VISUALIZZA_SELECTOR,
-                "els => els.map(e => e.getAttribute('title') || '')",
-            )
-            for i, row in enumerate(rows):
-                if i < len(titles) and titles[i]:
-                    row.title = titles[i]
+            text = self.page.locator("a.page-link.active").first.inner_text(timeout=2000)
+            return int(text.strip())
+        except Exception:
+            return 1
+
+    def current_rows(self) -> list[PortalRow]:
+        """Righe legate 1:1 al link Visualizza della stessa <tr>."""
+        assert self.page is not None
+        try:
+            items = self.page.evaluate(EXTRACT_LINKED_ROWS_JS)
+            rows = rows_from_link_dicts(items or [])
+            if rows:
+                return rows
         except Exception:
             pass
-        return rows
+        # fallback fixture-like (senza href) — sconsigliato in live
+        html = self.page.content()
+        return parse_table_html(html)
 
-    def download_row_pdf(self, row_index: int, tmp_path: Path) -> bytes:
-        """Apre dettaglio della riga N e scarica il PDF."""
+    def extract_detail_meta(self) -> dict:
         assert self.page is not None
         page = self.page
-        lista_url = page.url
-        tmp_path.parent.mkdir(parents=True, exist_ok=True)
-        vis = page.locator(VISUALIZZA_SELECTOR).nth(row_index)
-        href = vis.get_attribute("href") or ""
+        try:
+            text = page.inner_text("body", timeout=15000)
+        except Exception:
+            text = page.content()
+        return parse_detail_text(text, page_url=page.url)
+
+    def _raise_if_blocked(self, status: int | None = None, body_snippet: str = "") -> None:
+        snippet = (body_snippet or "").lower()
+        if status in (403, 429):
+            raise MefBlockedError(status, f"blocco HTTP {status}")
+        if status and status >= 500:
+            raise MefHttpError(status, f"HTTP {status}")
+        if any(x in snippet for x in ("captcha", "access denied", "akamai", "bot manager")):
+            raise MefBlockedError(status or 403, "possibile WAF/CAPTCHA")
+
+    def open_detail(self, row: PortalRow) -> dict:
+        """Apre il dettaglio via href della riga; ritorna metadati pagina dettaglio."""
+        assert self.page is not None
+        page = self.page
+        href = (row.href or "").strip()
         if href.startswith("/"):
             href = f"{SITE_ORIGIN}{href}"
         if href.startswith("http"):
-            page.goto(href, timeout=60000)
+            resp = None
+            try:
+                # goto non espone sempre status; controlla dopo
+                page.goto(href, timeout=60000, wait_until="domcontentloaded")
+            except Exception as exc:
+                msg = str(exc)
+                if "403" in msg:
+                    raise MefBlockedError(403, msg) from exc
+                if "429" in msg:
+                    raise MefBlockedError(429, msg) from exc
+                raise
         else:
-            vis.click()
+            # fallback: click sul Visualizza con stesso title/href se possibile
+            if row.row_index is None:
+                raise RuntimeError("riga senza href né row_index")
+            page.locator(VISUALIZZA_SELECTOR).nth(row.row_index).click()
         page.wait_for_url("**/ricerca/dettaglio/**", timeout=60000)
+        # segnali blocco sulla pagina
+        try:
+            body = page.content()
+            self._raise_if_blocked(body_snippet=body[:2000])
+        except MefBlockedError:
+            raise
+        except Exception:
+            pass
         page.wait_for_selector(DETTAGLIO_SCARICA_BTN, timeout=30000)
+        return self.extract_detail_meta()
+
+    def download_pdf_bytes(self, tmp_path: Path) -> bytes:
+        """Dalla pagina dettaglio già aperta, scarica i bytes PDF."""
+        assert self.page is not None
+        page = self.page
+        tmp_path.parent.mkdir(parents=True, exist_ok=True)
         try:
             with page.expect_download(timeout=90000) as download_info:
                 page.locator(DETTAGLIO_SCARICA_BTN).click()
@@ -113,7 +205,9 @@ class LiveMefClient:
         except Exception:
             pdf_url = page.evaluate(
                 """() => {
-                    const btn = document.querySelector('button[title="Scarica il pdf del provvedimento"]');
+                    const btn = document.querySelector(
+                      'button[title="Scarica il pdf del provvedimento"]'
+                    );
                     return btn ? (btn.getAttribute('data-url') || btn.dataset?.url || '') : '';
                 }"""
             )
@@ -121,25 +215,51 @@ class LiveMefClient:
                 onclick = page.locator(DETTAGLIO_SCARICA_BTN).get_attribute("onclick") or ""
                 m = re.search(r"https?://[^'\"\\s]+\.pdf", onclick, re.I)
                 pdf_url = m.group(0) if m else ""
-            if pdf_url:
-                if pdf_url.startswith("/"):
-                    pdf_url = f"{SITE_ORIGIN}{pdf_url}"
-                resp = page.context.request.get(pdf_url, timeout=90000)
-                if not resp.ok:
-                    raise RuntimeError(f"HTTP {resp.status} su PDF")
-                tmp_path.write_bytes(resp.body())
-            else:
-                raise
-        finally:
-            try:
-                if page.url != lista_url:
-                    page.goto(lista_url, timeout=60000)
-                    page.wait_for_selector(VISUALIZZA_SELECTOR, timeout=45000)
-            except Exception:
-                pass
-            time.sleep(0.5)
+            if not pdf_url:
+                raise RuntimeError("URL PDF non trovato sul dettaglio")
+            if pdf_url.startswith("/"):
+                pdf_url = f"{SITE_ORIGIN}{pdf_url}"
+            resp = page.context.request.get(pdf_url, timeout=90000)
+            status = resp.status
+            body = resp.body()
+            if status in (403, 429):
+                raise MefBlockedError(status, body[:200].decode("utf-8", "ignore"))
+            if status >= 500:
+                raise MefHttpError(status, f"HTTP {status} su PDF")
+            if not resp.ok:
+                raise MefHttpError(status, f"HTTP {status} su PDF")
+            tmp_path.write_bytes(body)
 
         data = tmp_path.read_bytes()
+        if data.lstrip().lower().startswith(b"<!doctype") or data.lstrip().lower().startswith(
+            b"<html"
+        ):
+            raise RuntimeError("download HTML invece di PDF")
         if not data.startswith(b"%PDF"):
             raise RuntimeError("download non è un PDF valido")
         return data
+
+    def back_to_list(self, lista_url: str) -> None:
+        assert self.page is not None
+        page = self.page
+        try:
+            if page.url != lista_url:
+                page.goto(lista_url, timeout=60000)
+                page.wait_for_selector(VISUALIZZA_SELECTOR, timeout=45000)
+        except Exception:
+            pass
+        time.sleep(0.3)
+
+    def fetch_row_pdf(self, row: PortalRow, tmp_path: Path) -> tuple[bytes, dict]:
+        """
+        Apre dettaglio della riga (via href), legge metadati dettaglio, scarica PDF.
+        Ritorna (pdf_bytes, detail_meta).
+        """
+        assert self.page is not None
+        lista_url = self.page.url
+        try:
+            detail_meta = self.open_detail(row)
+            data = self.download_pdf_bytes(tmp_path)
+            return data, detail_meta
+        finally:
+            self.back_to_list(lista_url)

--- a/scripts/scraper_mef/config.py
+++ b/scripts/scraper_mef/config.py
@@ -1,0 +1,70 @@
+"""Configurazione da env — nessun segreto hardcoded."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_TMP = ROOT / ".tmp_downloads"
+DEFAULT_CHECKPOINT = ROOT / ".checkpoint.json"
+DEFAULT_CACHE_KEYS = ROOT / "data" / "cache_nomi_base_local.txt"
+
+# Default tipici sul PC di Matteo (Fase 2 test locale)
+DEFAULT_MATTEO_SGAI = Path(r"C:\Users\meko srl\.cursor\Matteo_folder\SGAI")
+DEFAULT_OUTPUT_DIR = DEFAULT_MATTEO_SGAI / "downloads_mef"
+DEFAULT_SERVER_CACHES = [
+    Path(
+        r"C:\Users\meko srl\Downloads\SGAI_RAGFlow_pacchetto_collega_2026-07-24_1556"
+        r"\pacchetto_collega\dati\cache_nomi_base.txt"
+    ),
+    DEFAULT_MATTEO_SGAI / "mef_skip_from_d_2025.txt",
+    DEFAULT_MATTEO_SGAI / "mef_skip_from_d_all.txt",
+]
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return int(raw)
+
+
+def env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return float(raw)
+
+
+class Config:
+    def __init__(self) -> None:
+        self.tmp_dir = Path(os.environ.get("MEF_SCRAPER_TMP", str(DEFAULT_TMP)))
+        self.checkpoint_path = Path(
+            os.environ.get("MEF_SCRAPER_CHECKPOINT", str(DEFAULT_CHECKPOINT))
+        )
+        self.cache_keys_path = Path(
+            os.environ.get("MEF_SCRAPER_CACHE", str(DEFAULT_CACHE_KEYS))
+        )
+        self.output_dir = Path(
+            os.environ.get("MEF_SCRAPER_OUTPUT", str(DEFAULT_OUTPUT_DIR))
+        )
+        # Punto 3: default 1; hard-cap a 2 nel RunLimits
+        self.max_download_concurrency = max(1, min(2, env_int("MEF_SCRAPER_DL_CONCURRENCY", 1)))
+        self.max_upload_concurrency = max(1, min(1, env_int("MEF_SCRAPER_UL_CONCURRENCY", 1)))
+        self.page_delay_sec = env_float("MEF_SCRAPER_PAGE_DELAY", 25.0)
+        self.download_delay_min = env_float("MEF_SCRAPER_DL_DELAY_MIN", 18.0)
+        self.download_delay_max = env_float("MEF_SCRAPER_DL_DELAY_MAX", 32.0)
+        self.min_pdf_bytes = env_int("MEF_SCRAPER_MIN_PDF_BYTES", 1000)
+        self.max_pdf_bytes = env_int("MEF_SCRAPER_MAX_PDF_BYTES", 80_000_000)
+        self.upload_enabled = os.environ.get("MEF_SCRAPER_UPLOAD", "0") == "1"
+
+    def default_server_caches(self) -> list[Path]:
+        paths = []
+        env_list = os.environ.get("MEF_SCRAPER_SERVER_CACHES", "")
+        if env_list.strip():
+            paths.extend(Path(p.strip()) for p in env_list.split(";") if p.strip())
+        else:
+            paths.extend(DEFAULT_SERVER_CACHES)
+        # piccolo file locale del modulo (esempi |embedded)
+        paths.append(self.cache_keys_path)
+        return paths

--- a/scripts/scraper_mef/config.py
+++ b/scripts/scraper_mef/config.py
@@ -1,4 +1,4 @@
-"""Configurazione da env — nessun segreto hardcoded."""
+"""Configurazione da env / CLI — nessun path assoluto del PC sviluppatore."""
 from __future__ import annotations
 
 import os
@@ -8,18 +8,8 @@ ROOT = Path(__file__).resolve().parent
 DEFAULT_TMP = ROOT / ".tmp_downloads"
 DEFAULT_CHECKPOINT = ROOT / ".checkpoint.json"
 DEFAULT_CACHE_KEYS = ROOT / "data" / "cache_nomi_base_local.txt"
-
-# Default tipici sul PC di Matteo (Fase 2 test locale)
-DEFAULT_MATTEO_SGAI = Path(r"C:\Users\meko srl\.cursor\Matteo_folder\SGAI")
-DEFAULT_OUTPUT_DIR = DEFAULT_MATTEO_SGAI / "downloads_mef"
-DEFAULT_SERVER_CACHES = [
-    Path(
-        r"C:\Users\meko srl\Downloads\SGAI_RAGFlow_pacchetto_collega_2026-07-24_1556"
-        r"\pacchetto_collega\dati\cache_nomi_base.txt"
-    ),
-    DEFAULT_MATTEO_SGAI / "mef_skip_from_d_2025.txt",
-    DEFAULT_MATTEO_SGAI / "mef_skip_from_d_all.txt",
-]
+# Output relativo al modulo; override con MEF_SCRAPER_OUTPUT o --output-dir
+DEFAULT_OUTPUT_DIR = ROOT / "downloads_out"
 
 
 def env_int(name: str, default: int) -> int:
@@ -48,7 +38,7 @@ class Config:
         self.output_dir = Path(
             os.environ.get("MEF_SCRAPER_OUTPUT", str(DEFAULT_OUTPUT_DIR))
         )
-        # Punto 3: default 1; hard-cap a 2 nel RunLimits
+        # Concorrenza stub: default 1, hard-cap 2 (non è un worker pool reale)
         self.max_download_concurrency = max(1, min(2, env_int("MEF_SCRAPER_DL_CONCURRENCY", 1)))
         self.max_upload_concurrency = max(1, min(1, env_int("MEF_SCRAPER_UL_CONCURRENCY", 1)))
         self.page_delay_sec = env_float("MEF_SCRAPER_PAGE_DELAY", 25.0)
@@ -59,12 +49,13 @@ class Config:
         self.upload_enabled = os.environ.get("MEF_SCRAPER_UPLOAD", "0") == "1"
 
     def default_server_caches(self) -> list[Path]:
-        paths = []
+        """
+        Cache server solo da env MEF_SCRAPER_SERVER_CACHES (path separati da ';')
+        più il file locale del modulo. Nessun path assoluto hardcoded.
+        """
+        paths: list[Path] = []
         env_list = os.environ.get("MEF_SCRAPER_SERVER_CACHES", "")
         if env_list.strip():
             paths.extend(Path(p.strip()) for p in env_list.split(";") if p.strip())
-        else:
-            paths.extend(DEFAULT_SERVER_CACHES)
-        # piccolo file locale del modulo (esempi |embedded)
         paths.append(self.cache_keys_path)
         return paths

--- a/scripts/scraper_mef/data/cache_nomi_base_local.txt
+++ b/scripts/scraper_mef/data/cache_nomi_base_local.txt
@@ -1,0 +1,3 @@
+# Cache locale di esempio (Fase 2).
+# Una riga = nomeBase. Suffisso |embedded = skip download (già completo).
+Sentenza_V10_13747_2021|embedded

--- a/scripts/scraper_mef/data/codici_corte.json
+++ b/scripts/scraper_mef/data/codici_corte.json
@@ -1,0 +1,56 @@
+{
+  "note": "Mappatura ufficiale codici file SGAI/MEF. Il nome file e' sempre Sentenza_{CODICE}_{NUMERO}_{ANNO}.pdf",
+  "prefissi": {
+    "V": "1 grado provinciale - serie V (es. V10=Napoli, V08=Benevento, V14=Bari)",
+    "U": "1 grado provinciale - serie U (es. U01=Alessandria, U24=Milano, U91=Roma)",
+    "Z": "2 grado regionale (es. Z29=Campania, Z18=Lazio, Z31=Puglia)",
+    "eccezioni_2grado": "Alcune sezioni 2 grado usano prefisso V invece di Z (es. V92=Emilia-Romagna, V70=Lombardia, V88=Liguria)"
+  },
+  "esempi": [
+    {"portale": "CGT 2° Lombardia n. 1205/2026", "codice": "V70", "nomeFile": "Sentenza_V70_1205_2026.pdf"},
+    {"portale": "CGT 2° Puglia n. 1489/2026", "codice": "Z31", "nomeFile": "Sentenza_Z31_1489_2026.pdf"},
+    {"portale": "CGT 2° Lazio n. 2686/2026", "codice": "Z18", "nomeFile": "Sentenza_Z18_2686_2026.pdf"},
+    {"portale": "CGT 2° Sicilia n. 3338/2026", "codice": "Z46", "nomeFile": "Sentenza_Z46_3338_2026.pdf"},
+    {"portale": "CGT 1° Bologna n. 386/2026", "codice": "U55", "nomeFile": "Sentenza_U55_386_2026.pdf"},
+    {"portale": "CGT 1° Napoli n. 13747/2021", "codice": "V10", "nomeFile": "Sentenza_V10_13747_2021.pdf"}
+  ],
+  "tabellaPortale2026": {
+    "colonne": ["tipo", "numero", "anno", "corte", "data", "importo", "..."],
+    "indiciTd": {"tipo": 0, "numero": 1, "anno": 2, "corte": 3},
+    "nota": "Il PDF scaricato ha nome gibberish. Usare sempre numero+anno+corte dalla tabella."
+  },
+  "corteToCodice": {
+    "1°_AGRIGENTO": "V36", "1°_ALESSANDRIA": "U01", "1°_ANCONA": "U79", "1°_AREZZO": "U64",
+    "1°_ASCOLI_PICENO": "U80", "1°_ASTI": "U04", "1°_AVELLINO": "V06", "1°_BARI": "V14",
+    "1°_BELLUNO": "U36", "1°_BENEVENTO": "V08", "1°_BERGAMO": "U17", "1°_BIELLA": "U14",
+    "1°_BOLOGNA": "U55", "1°_BOLZANO": "U33", "1°_BRESCIA": "U18", "1°_BRINDISI": "V16",
+    "1°_CAGLIARI": "V53", "1°_CALTANISSETTA": "V38", "1°_CAMPOBASSO": "V02", "1°_CASERTA": "Z55",
+    "1°_CATANIA": "V40", "1°_CATANZARO": "V25", "1°_CHIETI": "U97", "1°_COMO": "U19",
+    "1°_COSENZA": "V22", "1°_CREMONA": "U22", "1°_CROTONE": "V26", "1°_CUNEO": "U06",
+    "1°_ENNA": "V41", "1°_FERRARA": "U56", "1°_FIRENZE": "U65", "1°_FOGGIA": "V17",
+    "1°_FORLÌ": "U57", "1°_FROSINONE": "U87", "1°_GENOVA": "U50", "1°_GORIZIA": "U44",
+    "1°_GROSSETO": "U67", "1°_IMPERIA": "U51", "1°_ISERNIA": "V04", "1°_L'AQUILA": "U95",
+    "1°_LA_SPEZIA": "U53", "1°_LATINA": "U88", "1°_LECCE": "V19", "1°_LECCO": "U20",
+    "1°_LIVORNO": "U68", "1°_LODI": "U23", "1°_LUCCA": "U69", "1°_MACERATA": "U83",
+    "1°_MANTOVA": "U26", "1°_MASSA_CARRARA": "U70", "1°_MATERA": "V32", "1°_MESSINA": "V43",
+    "1°_MILANO": "U24", "1°_MODENA": "U59", "1°_MONZA": "U25", "1°_NAPOLI": "V10",
+    "1°_NOVARA": "U09", "1°_NUORO": "V55", "1°_ORISTANO": "V56", "1°_PADOVA": "U37",
+    "1°_PALERMO": "V46", "1°_PARMA": "U61", "1°_PAVIA": "U27", "1°_PERUGIA": "U75",
+    "1°_PESARO": "U84", "1°_PESCARA": "V00", "1°_PIACENZA": "U60", "1°_PISA": "U71",
+    "1°_PISTOIA": "U72", "1°_PORDENONE": "U45", "1°_POTENZA": "V35", "1°_PRATO": "U66",
+    "1°_RAGUSA": "V49", "1°_RAVENNA": "U62", "1°_REGGIO_CALABRIA": "V31", "1°_REGGIO_NELL'EMILIA": "U63",
+    "1°_RIETI": "U89", "1°_RIMINI": "U58", "1°_ROMA": "U91", "1°_ROVIGO": "U38",
+    "1°_SALERNO": "V12", "1°_SASSARI": "V57", "1°_SAVONA": "U54", "1°_SIENA": "U74",
+    "1°_SIRACUSA": "V50", "1°_SONDRIO": "U30", "1°_TARANTO": "V20", "1°_TERAMO": "V01",
+    "1°_TERNI": "U78", "1°_TREVISO": "U39", "1°_TRIESTE": "U46", "1°_TRENTO": "U35",
+    "1°_TORINO": "U13", "1°_TRAPANI": "V52", "1°_UDINE": "U48", "1°_VARESE": "U32",
+    "1°_VENEZIA": "U40", "1°_VERBANIA": "U10", "1°_VERCELLI": "U15", "1°_VERONA": "U43",
+    "1°_VIBO_VALENTIA": "V28", "1°_VICENZA": "U42", "1°_VITERBO": "U93", "1°_AOSTA": "U16",
+    "2°_ABRUZZO": "Z20", "2°_BASILICATA": "Z40", "2°_CALABRIA": "Z37", "2°_CAMPANIA": "Z29",
+    "2°_EMILIA_ROMAGNA": "V92", "2°_FRIULI_VENEZIA_GIULIA": "V86", "2°_LAZIO": "Z18",
+    "2°_LIGURIA": "V88", "2°_LOMBARDIA": "V70", "2°_MARCHE": "Z11", "2°_MOLISE": "Z24",
+    "2°_PIEMONTE": "V63", "2°_PUGLIA": "Z31", "2°_SARDEGNA": "Z50", "2°_SICILIA": "Z46",
+    "2°_TOSCANA": "Z01", "2°_TRENTINO_ALTO_ADIGE": "V75", "2°_UMBRIA": "Z09",
+    "2°_VALLE_D'AOSTA": "V65", "2°_VENETO": "V81"
+  }
+}

--- a/scripts/scraper_mef/download.py
+++ b/scripts/scraper_mef/download.py
@@ -1,13 +1,27 @@
-"""Download PDF + verifiche + salvataggio atomico in output_dir."""
+"""Download PDF + verifiche rafforzate + salvataggio atomico."""
 from __future__ import annotations
 
 import hashlib
 import os
+import re
 from pathlib import Path
 
 
 def is_pdf_bytes(data: bytes) -> bool:
     return data[:5] == b"%PDF-"
+
+
+def looks_like_html(data: bytes) -> bool:
+    head = data[:512].lstrip().lower()
+    return head.startswith(b"<!doctype") or head.startswith(b"<html") or b"<html" in head[:200]
+
+
+def has_pdf_eof(data: bytes) -> bool:
+    """%%EOF tipicamente in coda; assenza = PDF troncato/incompleto."""
+    if not data:
+        return False
+    tail = data[-8192:] if len(data) > 8192 else data
+    return b"%%EOF" in tail
 
 
 def sha256_bytes(data: bytes) -> str:
@@ -16,17 +30,19 @@ def sha256_bytes(data: bytes) -> str:
 
 def make_minimal_pdf(min_bytes: int = 1200) -> bytes:
     """PDF sintetico solo per --simulate (non è una sentenza reale)."""
-    core = (
+    head = (
         b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
         b"1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n"
         b"2 0 obj<< /Type /Pages /Kids [] /Count 0 >>endobj\n"
         b"xref\n0 3\n0000000000 65535 f \n"
         b"trailer<< /Size 3 /Root 1 0 R >>\n"
-        b"startxref\n0\n%%EOF\n"
+        b"startxref\n0\n"
     )
-    if len(core) >= min_bytes:
-        return core
-    return core + (b"%" + b"0" * (min_bytes - len(core) - 1) + b"\n")
+    eof = b"%%EOF\n"
+    if len(head) + len(eof) >= min_bytes:
+        return head + eof
+    pad_len = min_bytes - len(head) - len(eof)
+    return head + (b"%" + b"0" * max(0, pad_len - 1) + b"\n")[:pad_len] + eof
 
 
 def verify_pdf(
@@ -36,16 +52,83 @@ def verify_pdf(
     max_bytes: int,
 ) -> list[str]:
     errors: list[str] = []
+    if not data:
+        errors.append("vuoto")
+        return errors
+    if looks_like_html(data):
+        errors.append("contenuto HTML invece di PDF")
     if len(data) < min_bytes:
         errors.append(f"troppo piccolo: {len(data)} < {min_bytes}")
     if len(data) > max_bytes:
         errors.append(f"troppo grande: {len(data)} > {max_bytes}")
     if not is_pdf_bytes(data):
         errors.append("firma PDF assente (%PDF-)")
-        head = data[:200].lstrip().lower()
-        if head.startswith(b"<!doctype") or head.startswith(b"<html"):
-            errors.append("contenuto HTML invece di PDF")
+    elif not has_pdf_eof(data):
+        errors.append("%%EOF assente (PDF incompleto/troncato)")
+    # bytes nulli eccessivi all'inizio = spesso download corrotto
+    if data[:64].count(b"\x00") > 32:
+        errors.append("troppi null bytes in testa (corrotto)")
     return errors
+
+
+def validate_local_pdf(
+    path: Path,
+    *,
+    min_bytes: int,
+    max_bytes: int,
+) -> list[str]:
+    """Validazione file già su disco: esistenza, size, firma, EOF, leggibilità base."""
+    if not path.exists():
+        return ["non esiste"]
+    if not path.is_file():
+        return ["non è un file"]
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        return [f"stat fallita: {exc}"]
+    if size <= 0:
+        return ["size 0"]
+    errors: list[str] = []
+    if size < min_bytes:
+        errors.append(f"troppo piccolo: {size} < {min_bytes}")
+    if size > max_bytes:
+        errors.append(f"troppo grande: {size} > {max_bytes}")
+    try:
+        with path.open("rb") as fh:
+            if size <= 8192:
+                data = fh.read()
+                head = data[:1024]
+                tail = data
+            else:
+                head = fh.read(1024)
+                fh.seek(max(0, size - 8192))
+                tail = fh.read(8192)
+    except OSError as exc:
+        return [f"non leggibile: {exc}"]
+    if looks_like_html(head):
+        errors.append("contenuto HTML invece di PDF")
+    if not is_pdf_bytes(head):
+        errors.append("firma PDF assente (%PDF-)")
+    elif not has_pdf_eof(tail):
+        errors.append("%%EOF assente (PDF incompleto/troncato)")
+    if head[:64].count(b"\x00") > 32:
+        errors.append("troppi null bytes in testa (corrotto)")
+    return errors
+
+
+def local_pdf_ok(path: Path, *, min_bytes: int, max_bytes: int) -> bool:
+    return not validate_local_pdf(path, min_bytes=min_bytes, max_bytes=max_bytes)
+
+
+def sha256_file(path: Path, *, chunk: int = 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            block = fh.read(chunk)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
 
 
 def save_pdf_atomic(dest: Path, data: bytes, *, overwrite: bool = False) -> dict:
@@ -92,3 +175,33 @@ def cleanup_tmp_dir(tmp_dir: Path, keep_newest: int = 20) -> int:
         except OSError:
             pass
     return removed
+
+
+_NOME_RE = re.compile(
+    r"^(?P<tipo>[A-Za-zÀ-ÿ]+)_(?P<codice>[A-Za-z]\d{2})_(?P<numero>\d+)_(?P<anno>\d{4})$"
+)
+
+
+def parse_nome_base(nome_base: str) -> dict | None:
+    base = nome_base[:-4] if nome_base.lower().endswith(".pdf") else nome_base
+    m = _NOME_RE.match(base)
+    if not m:
+        return None
+    return m.groupdict()
+
+
+def coherence_nome_vs_meta(nome_base: str, meta: dict) -> list[str]:
+    """Controlla che nome file e metadati (numero/anno/codice/tipo) coincidano."""
+    parsed = parse_nome_base(nome_base)
+    if not parsed:
+        return [f"nomeBase non canonico: {nome_base}"]
+    errors = []
+    for key in ("tipo", "codice", "numero", "anno"):
+        expected = str(meta.get(key, "")).strip()
+        got = str(parsed.get(key, "")).strip()
+        if key == "tipo":
+            if expected and got.lower() != expected.lower():
+                errors.append(f"coerenza {key}: nome={got} meta={expected}")
+        elif expected and got != expected:
+            errors.append(f"coerenza {key}: nome={got} meta={expected}")
+    return errors

--- a/scripts/scraper_mef/download.py
+++ b/scripts/scraper_mef/download.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import os
 import re
 from pathlib import Path
@@ -29,20 +30,74 @@ def sha256_bytes(data: bytes) -> str:
 
 
 def make_minimal_pdf(min_bytes: int = 1200) -> bytes:
-    """PDF sintetico solo per --simulate (non è una sentenza reale)."""
-    head = (
-        b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
-        b"1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n"
-        b"2 0 obj<< /Type /Pages /Kids [] /Count 0 >>endobj\n"
-        b"xref\n0 3\n0000000000 65535 f \n"
-        b"trailer<< /Size 3 /Root 1 0 R >>\n"
-        b"startxref\n0\n"
-    )
-    eof = b"%%EOF\n"
-    if len(head) + len(eof) >= min_bytes:
-        return head + eof
-    pad_len = min_bytes - len(head) - len(eof)
-    return head + (b"%" + b"0" * max(0, pad_len - 1) + b"\n")[:pad_len] + eof
+    """PDF sintetico valido per pypdf (solo --simulate; non è una sentenza reale)."""
+    from pypdf import PdfWriter
+
+    buf = io.BytesIO()
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.write(buf)
+    data = buf.getvalue()
+    if len(data) >= min_bytes:
+        return data
+    # Padding dopo %%EOF: non altera trailer/catalogo; has_pdf_eof resta vero
+    pad_len = min_bytes - len(data)
+    return data + (b"\n%" + b"0" * max(0, pad_len - 2) + b"\n")[:pad_len]
+
+
+def verify_pdf_structure(data: bytes) -> list[str]:
+    """
+    Validazione strutturale con pypdf: trailer + catalogo /Root.
+    %PDF- + %%EOF da soli non bastano (payload non-PDF possono passarli).
+    """
+    errors: list[str] = []
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        return ["pypdf non disponibile (richiesto per validazione strutturale)"]
+
+    try:
+        reader = PdfReader(io.BytesIO(data), strict=False)
+    except Exception as exc:  # noqa: BLE001 — qualsiasi fallimento parser = PDF invalido
+        return [f"parser PDF fallito: {exc}"]
+
+    try:
+        trailer = reader.trailer
+        if trailer is None:
+            errors.append("trailer PDF assente")
+        else:
+            root = trailer.get("/Root")
+            if root is None:
+                errors.append("catalogo /Root assente nel trailer")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"trailer PDF non leggibile: {exc}")
+
+    try:
+        root_obj = reader.root_object
+        if root_obj is None:
+            errors.append("root_object assente")
+        else:
+            rtype = root_obj.get("/Type") if hasattr(root_obj, "get") else None
+            if rtype is not None and str(rtype) not in ("/Catalog", "Catalog"):
+                errors.append(f"root non è Catalog: {rtype}")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"catalogo PDF non accessibile: {exc}")
+
+    try:
+        # Accesso pagine: fallisce su strutture rotte anche se header/EOF ok
+        _ = len(reader.pages)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"pagine PDF non leggibili: {exc}")
+
+    return errors
+
+
+def verify_pdf_structure_path(path: Path) -> list[str]:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return [f"non leggibile: {exc}"]
+    return verify_pdf_structure(data)
 
 
 def verify_pdf(
@@ -68,6 +123,10 @@ def verify_pdf(
     # bytes nulli eccessivi all'inizio = spesso download corrotto
     if data[:64].count(b"\x00") > 32:
         errors.append("troppi null bytes in testa (corrotto)")
+    # Se i check grezzi falliscono, non serve il parser
+    if errors:
+        return errors
+    errors.extend(verify_pdf_structure(data))
     return errors
 
 
@@ -77,7 +136,7 @@ def validate_local_pdf(
     min_bytes: int,
     max_bytes: int,
 ) -> list[str]:
-    """Validazione file già su disco: esistenza, size, firma, EOF, leggibilità base."""
+    """Validazione file già su disco: size, firma, EOF, struttura pypdf."""
     if not path.exists():
         return ["non esiste"]
     if not path.is_file():
@@ -95,14 +154,15 @@ def validate_local_pdf(
         errors.append(f"troppo grande: {size} > {max_bytes}")
     try:
         with path.open("rb") as fh:
-            if size <= 8192:
+            if size <= 2_000_000:
                 data = fh.read()
                 head = data[:1024]
-                tail = data
+                tail = data[-8192:] if len(data) > 8192 else data
             else:
                 head = fh.read(1024)
                 fh.seek(max(0, size - 8192))
                 tail = fh.read(8192)
+                data = None
     except OSError as exc:
         return [f"non leggibile: {exc}"]
     if looks_like_html(head):
@@ -113,6 +173,12 @@ def validate_local_pdf(
         errors.append("%%EOF assente (PDF incompleto/troncato)")
     if head[:64].count(b"\x00") > 32:
         errors.append("troppi null bytes in testa (corrotto)")
+    if errors:
+        return errors
+    if data is not None:
+        errors.extend(verify_pdf_structure(data))
+    else:
+        errors.extend(verify_pdf_structure_path(path))
     return errors
 
 

--- a/scripts/scraper_mef/download.py
+++ b/scripts/scraper_mef/download.py
@@ -1,0 +1,94 @@
+"""Download PDF + verifiche + salvataggio atomico in output_dir."""
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+
+def is_pdf_bytes(data: bytes) -> bool:
+    return data[:5] == b"%PDF-"
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def make_minimal_pdf(min_bytes: int = 1200) -> bytes:
+    """PDF sintetico solo per --simulate (non è una sentenza reale)."""
+    core = (
+        b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+        b"1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n"
+        b"2 0 obj<< /Type /Pages /Kids [] /Count 0 >>endobj\n"
+        b"xref\n0 3\n0000000000 65535 f \n"
+        b"trailer<< /Size 3 /Root 1 0 R >>\n"
+        b"startxref\n0\n%%EOF\n"
+    )
+    if len(core) >= min_bytes:
+        return core
+    return core + (b"%" + b"0" * (min_bytes - len(core) - 1) + b"\n")
+
+
+def verify_pdf(
+    data: bytes,
+    *,
+    min_bytes: int,
+    max_bytes: int,
+) -> list[str]:
+    errors: list[str] = []
+    if len(data) < min_bytes:
+        errors.append(f"troppo piccolo: {len(data)} < {min_bytes}")
+    if len(data) > max_bytes:
+        errors.append(f"troppo grande: {len(data)} > {max_bytes}")
+    if not is_pdf_bytes(data):
+        errors.append("firma PDF assente (%PDF-)")
+        head = data[:200].lstrip().lower()
+        if head.startswith(b"<!doctype") or head.startswith(b"<html"):
+            errors.append("contenuto HTML invece di PDF")
+    return errors
+
+
+def save_pdf_atomic(dest: Path, data: bytes, *, overwrite: bool = False) -> dict:
+    """Scrive via file .tmp poi os.replace. Ritorna info sha/size."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists() and not overwrite:
+        raise FileExistsError(str(dest))
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, dest)
+    return {
+        "path": str(dest),
+        "sha256": sha256_bytes(data),
+        "size": len(data),
+    }
+
+
+def ingest_pdf_bytes(
+    data: bytes,
+    dest: Path,
+    *,
+    min_bytes: int,
+    max_bytes: int,
+    overwrite: bool = False,
+) -> dict:
+    errors = verify_pdf(data, min_bytes=min_bytes, max_bytes=max_bytes)
+    if errors:
+        return {"ok": False, "errors": errors}
+    info = save_pdf_atomic(dest, data, overwrite=overwrite)
+    return {"ok": True, **info}
+
+
+def cleanup_tmp_dir(tmp_dir: Path, keep_newest: int = 20) -> int:
+    """Non accumulare migliaia di PDF temp: tiene solo i più recenti."""
+    if not tmp_dir.exists():
+        return 0
+    files = sorted(tmp_dir.glob("*"), key=lambda p: p.stat().st_mtime, reverse=True)
+    removed = 0
+    for path in files[keep_newest:]:
+        try:
+            if path.is_file():
+                path.unlink()
+                removed += 1
+        except OSError:
+            pass
+    return removed

--- a/scripts/scraper_mef/fixtures/sample_rows.html
+++ b/scripts/scraper_mef/fixtures/sample_rows.html
@@ -1,0 +1,38 @@
+<!-- Fixture per test skip a 3 livelli (dry-run --use-matteo-paths) -->
+<table>
+  <!-- A: già in downloads_mef -->
+  <tr>
+    <td>Sentenza</td>
+    <td>100</td>
+    <td>2025</td>
+    <td>CGT 2° Lombardia</td>
+  </tr>
+  <!-- A+B: in downloads_mef e anche in skip D: -->
+  <tr>
+    <td>Sentenza</td>
+    <td>100</td>
+    <td>2025</td>
+    <td>CGT 1° Alessandria</td>
+  </tr>
+  <!-- B: in mef_skip / cache, NON in downloads_mef -->
+  <tr>
+    <td>Sentenza</td>
+    <td>6086</td>
+    <td>2025</td>
+    <td>CGT 1° Roma</td>
+  </tr>
+  <!-- C: non in locale né (tipicamente) in cache 2025 server → would_download -->
+  <tr>
+    <td>Sentenza</td>
+    <td>1205</td>
+    <td>2026</td>
+    <td>CGT 2° Lombardia</td>
+  </tr>
+  <!-- embedded esempio nel file cache locale del modulo -->
+  <tr>
+    <td>Sentenza</td>
+    <td>13747</td>
+    <td>2021</td>
+    <td>CGT 1° Napoli</td>
+  </tr>
+</table>

--- a/scripts/scraper_mef/limits.py
+++ b/scripts/scraper_mef/limits.py
@@ -1,0 +1,93 @@
+"""Punto 3 — limiti di carico, delay, stop pulito."""
+from __future__ import annotations
+
+import random
+import signal
+import threading
+import time
+from contextlib import contextmanager
+
+
+class StopController:
+    """Stop pulito: completa il file corrente, non partire con uno nuovo."""
+
+    def __init__(self) -> None:
+        self._stop = threading.Event()
+        self._installed = False
+
+    def request_stop(self, *_args) -> None:
+        self._stop.set()
+
+    @property
+    def should_stop(self) -> bool:
+        return self._stop.is_set()
+
+    def install_signals(self) -> None:
+        if self._installed:
+            return
+        try:
+            signal.signal(signal.SIGINT, self.request_stop)
+            signal.signal(signal.SIGTERM, self.request_stop)
+        except Exception:
+            # Windows / thread secondari
+            pass
+        self._installed = True
+
+
+class RunLimits:
+    """
+    Limiti Fase 2:
+    - max 1 download alla volta (semaforo)
+    - delay variabile tra download
+    - non accumulare tmp all'infinito (cleanup caller)
+    """
+
+    def __init__(
+        self,
+        *,
+        max_download_concurrency: int = 1,
+        delay_min: float = 18.0,
+        delay_max: float = 32.0,
+        page_delay: float = 25.0,
+    ) -> None:
+        self.max_download_concurrency = max(1, min(2, int(max_download_concurrency)))
+        self.delay_min = float(delay_min)
+        self.delay_max = max(self.delay_min, float(delay_max))
+        self.page_delay = float(page_delay)
+        self._sem = threading.Semaphore(self.max_download_concurrency)
+        self.stop = StopController()
+
+    @contextmanager
+    def download_slot(self):
+        self._sem.acquire()
+        try:
+            yield
+        finally:
+            self._sem.release()
+
+    def pause_between_downloads(self, log=None) -> None:
+        delay = random.uniform(self.delay_min, self.delay_max)
+        # jitter anti-pattern fisso
+        delay += random.uniform(0.2, 2.5)
+        if log:
+            log(f"pausa download {delay:.1f}s (limite {self.delay_min:.0f}-{self.delay_max:.0f}s)")
+        # interruptible sleep
+        end = time.time() + delay
+        while time.time() < end:
+            if self.stop.should_stop:
+                return
+            time.sleep(min(0.5, end - time.time()))
+
+    def pause_between_pages(self, log=None) -> None:
+        delay = random.triangular(
+            self.page_delay * 0.85,
+            self.page_delay * 1.35,
+            self.page_delay,
+        )
+        if log:
+            log(f"pausa pagina {delay:.1f}s")
+        end = time.time() + delay
+        while time.time() < end:
+            if self.stop.should_stop:
+                return
+            time.sleep(min(0.5, end - time.time()))

--- a/scripts/scraper_mef/limits.py
+++ b/scripts/scraper_mef/limits.py
@@ -66,6 +66,8 @@ class RunLimits:
             self._sem.release()
 
     def pause_between_downloads(self, log=None) -> None:
+        if self.delay_max <= 0:
+            return
         delay = random.uniform(self.delay_min, self.delay_max)
         # jitter anti-pattern fisso
         delay += random.uniform(0.2, 2.5)

--- a/scripts/scraper_mef/logging_utils.py
+++ b/scripts/scraper_mef/logging_utils.py
@@ -1,0 +1,19 @@
+"""Logging senza cookie, token o contenuto PDF."""
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def setup_logger(name: str = "scraper_mef", level: int = logging.INFO) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    logger.propagate = False
+    return logger

--- a/scripts/scraper_mef/metrics.py
+++ b/scripts/scraper_mef/metrics.py
@@ -11,10 +11,13 @@ class Metrics:
     skipped_server: int = 0
     skipped_embedded: int = 0
     skipped_invalid: int = 0
+    skipped_checkpoint: int = 0
     would_download: int = 0
+    attempts: int = 0
     downloaded: int = 0
     uploaded: int = 0
     errors: int = 0
+    blocked: int = 0
 
     def as_dict(self) -> dict:
         return asdict(self)

--- a/scripts/scraper_mef/metrics.py
+++ b/scripts/scraper_mef/metrics.py
@@ -1,0 +1,20 @@
+"""Contatori scraper."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class Metrics:
+    discovered: int = 0
+    skipped_local: int = 0
+    skipped_server: int = 0
+    skipped_embedded: int = 0
+    skipped_invalid: int = 0
+    would_download: int = 0
+    downloaded: int = 0
+    uploaded: int = 0
+    errors: int = 0
+
+    def as_dict(self) -> dict:
+        return asdict(self)

--- a/scripts/scraper_mef/names.py
+++ b/scripts/scraper_mef/names.py
@@ -1,0 +1,21 @@
+"""
+Normalizzazione nome file SGAI.
+
+Usa la mappa corti in data/codici_corte.json tramite portal_to_filename.py
+(fonte allineata al pacchetto collega). Quando in repo comparirà
+api/utils/sentenze_utils.py, andrà usato quello come fonte canonica unica.
+"""
+from __future__ import annotations
+
+from . import portal_to_filename as portal
+
+
+def row_to_filename(numero: str, anno: str, corte: str, tipo: str = "Sentenza") -> dict:
+    return portal.build_filename(corte, numero, anno, tipo=tipo)
+
+
+def title_to_filename(title: str) -> dict:
+    result = portal.parse_portal_title(title)
+    if not result:
+        return {"ok": False, "error": "Title non interpretabile", "portalTitle": title}
+    return result

--- a/scripts/scraper_mef/parse.py
+++ b/scripts/scraper_mef/parse.py
@@ -1,12 +1,26 @@
-"""Estrazione metadati da riga tabella HTML o title link."""
+"""Estrazione metadati da riga tabella HTML, title link o pagina dettaglio."""
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from typing import Iterable
 
 from .names import row_to_filename, title_to_filename
+from .portal_to_filename import build_filename, normalize_tipo
+
+DETAIL_NUM_ANNO_RE = re.compile(
+    r"n\.?\s*(\d+)\s*/\s*(\d{4})",
+    re.IGNORECASE,
+)
+DETAIL_CORTE_RE = re.compile(
+    r"CGT\s*(1|2)\s*[°º]?\s+([A-Za-zÀ-ÿ' ]+?)(?:\s*$|\s{2,}|\n|<)",
+    re.IGNORECASE,
+)
+DETAIL_TIPO_RE = re.compile(
+    r"\b(Sentenza|Ordinanza|Decreto|Pronuncia)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -16,13 +30,39 @@ class PortalRow:
     anno: str
     corte: str
     title: str | None = None
+    href: str | None = None
+    row_index: int | None = None
+    extra: dict = field(default_factory=dict)
 
     def to_meta(self) -> dict:
+        # Preferisci celle tabella (includono tipo); title come fallback
+        meta = row_to_filename(self.numero, self.anno, self.corte, self.tipo)
+        if meta.get("ok"):
+            if self.title:
+                meta["portalTitle"] = self.title
+            if self.href:
+                meta["href"] = self.href
+            return meta
         if self.title:
-            meta = title_to_filename(self.title)
-            if meta.get("ok"):
-                return meta
-        return row_to_filename(self.numero, self.anno, self.corte, self.tipo)
+            tmeta = title_to_filename(self.title)
+            if tmeta.get("ok"):
+                # applica tipo dalla riga se title non lo porta
+                if self.tipo:
+                    rebuilt = build_filename(
+                        tmeta.get("cortePortale") or self.corte,
+                        tmeta["numero"],
+                        tmeta["anno"],
+                        tipo=self.tipo,
+                    )
+                    if rebuilt.get("ok"):
+                        rebuilt["portalTitle"] = self.title
+                        if self.href:
+                            rebuilt["href"] = self.href
+                        return rebuilt
+                if self.href:
+                    tmeta["href"] = self.href
+                return tmeta
+        return meta
 
 
 class _TableParser(HTMLParser):
@@ -55,10 +95,11 @@ class _TableParser(HTMLParser):
 
 
 def parse_table_html(html: str) -> list[PortalRow]:
+    """Parse semplice per fixture (senza link). Non usare per live con Visualizza."""
     parser = _TableParser()
     parser.feed(html)
     out: list[PortalRow] = []
-    for cells in parser.rows:
+    for i, cells in enumerate(parser.rows):
         if len(cells) < 4:
             continue
         tipo, numero, anno, corte = cells[0], cells[1], cells[2], cells[3]
@@ -66,18 +107,116 @@ def parse_table_html(html: str) -> list[PortalRow]:
             continue
         if not re.fullmatch(r"\d{4}", anno or ""):
             continue
-        out.append(PortalRow(tipo=tipo, numero=numero, anno=anno, corte=corte))
+        out.append(
+            PortalRow(
+                tipo=tipo or "Sentenza",
+                numero=numero,
+                anno=anno,
+                corte=corte,
+                row_index=i,
+            )
+        )
     return out
+
+
+def rows_from_link_dicts(items: list[dict]) -> list[PortalRow]:
+    """
+    Costruisce righe da oggetti {href, title, cells/tipo/numero/...}
+    prodotti da JS link.closest('tr') — associazione per riga DOM, non per indice filtrato.
+    """
+    out: list[PortalRow] = []
+    for i, item in enumerate(items or []):
+        cells = item.get("cells") or []
+        tipo = (item.get("tipo") or (cells[0] if len(cells) > 0 else "") or "Sentenza").strip()
+        numero = (item.get("numero") or (cells[1] if len(cells) > 1 else "") or "").strip()
+        anno = (item.get("anno") or (cells[2] if len(cells) > 2 else "") or "").strip()
+        corte = (item.get("corte") or (cells[3] if len(cells) > 3 else "") or "").strip()
+        title = item.get("title") or item.get("download_title")
+        href = item.get("href") or item.get("download_href")
+        out.append(
+            PortalRow(
+                tipo=tipo or "Sentenza",
+                numero=numero,
+                anno=anno,
+                corte=corte,
+                title=title,
+                href=href,
+                row_index=int(item.get("row_index", i)),
+                extra={"raw": item},
+            )
+        )
+    return out
+
+
+def parse_detail_text(text: str, *, page_url: str = "") -> dict:
+    """
+    Estrae numero/anno/corte/tipo dal testo (o HTML) della pagina dettaglio MEF.
+    Fonte autoritativa per allineare PDF ↔ metadati.
+    """
+    raw = text or ""
+    # preferisci testo visibile: strip tag grezzi
+    plain = re.sub(r"<script[\s\S]*?</script>", " ", raw, flags=re.I)
+    plain = re.sub(r"<style[\s\S]*?</style>", " ", plain, flags=re.I)
+    plain = re.sub(r"<[^>]+>", " ", plain)
+    plain = re.sub(r"\s+", " ", plain).strip()
+
+    m_num = DETAIL_NUM_ANNO_RE.search(plain)
+    m_corte = DETAIL_CORTE_RE.search(plain)
+    m_tipo = DETAIL_TIPO_RE.search(plain)
+
+    numero = m_num.group(1) if m_num else ""
+    anno = m_num.group(2) if m_num else ""
+    corte = ""
+    if m_corte:
+        corte = f"CGT {m_corte.group(1)}° {m_corte.group(2).strip()}"
+    tipo = normalize_tipo(m_tipo.group(1) if m_tipo else "Sentenza")
+
+    if not (numero and anno and corte):
+        return {
+            "ok": False,
+            "error": "metadati dettaglio incompleti",
+            "numero": numero,
+            "anno": anno,
+            "cortePortale": corte,
+            "tipo": tipo,
+            "pageUrl": page_url,
+            "snippet": plain[:240],
+        }
+    result = build_filename(corte, numero, anno, tipo=tipo)
+    result["pageUrl"] = page_url
+    result["source"] = "detail_page"
+    return result
+
+
+def metas_match(list_meta: dict, detail_meta: dict) -> list[str]:
+    """Verifica allineamento lista ↔ dettaglio (numero/anno/codice; tipo soft)."""
+    errors: list[str] = []
+    if not detail_meta.get("ok"):
+        errors.append(detail_meta.get("error") or "dettaglio non ok")
+        return errors
+    for key in ("numero", "anno", "codice"):
+        a = str(list_meta.get(key, "")).strip()
+        b = str(detail_meta.get(key, "")).strip()
+        if a and b and a != b:
+            errors.append(f"mismatch {key}: lista={a} dettaglio={b}")
+    # tipo: avvisa ma non blocca se lista vuota; se entrambi presenti e diversi → errore
+    ta = str(list_meta.get("tipo", "")).strip().lower()
+    tb = str(detail_meta.get("tipo", "")).strip().lower()
+    if ta and tb and ta != tb:
+        errors.append(f"mismatch tipo: lista={list_meta.get('tipo')} dettaglio={detail_meta.get('tipo')}")
+    return errors
 
 
 def validate_row(row: PortalRow) -> list[str]:
     errors: list[str] = []
-    if not row.numero:
-        errors.append("numero mancante")
-    if not row.anno:
-        errors.append("anno mancante")
+    if not row.numero or not re.fullmatch(r"\d+", row.numero):
+        errors.append("numero mancante o non numerico")
+    if not row.anno or not re.fullmatch(r"\d{4}", row.anno):
+        errors.append("anno mancante o non valido")
     if not row.corte:
         errors.append("corte mancante")
+    if errors:
+        return errors
     meta = row.to_meta()
     if not meta.get("ok"):
         errors.append(meta.get("error") or "nome non calcolabile")

--- a/scripts/scraper_mef/parse.py
+++ b/scripts/scraper_mef/parse.py
@@ -14,7 +14,7 @@ DETAIL_NUM_ANNO_RE = re.compile(
     re.IGNORECASE,
 )
 DETAIL_CORTE_RE = re.compile(
-    r"CGT\s*(1|2)\s*[°º]?\s+([A-Za-zÀ-ÿ' ]+?)(?:\s*$|\s{2,}|\n|<)",
+    r"CGT\s*(1|2)\s*[°º]?\s+([A-Za-zÀ-ÿ'\- ]+?)(?:\s*$|\s{2,}|\n|<)",
     re.IGNORECASE,
 )
 DETAIL_TIPO_RE = re.compile(

--- a/scripts/scraper_mef/parse.py
+++ b/scripts/scraper_mef/parse.py
@@ -1,0 +1,93 @@
+"""Estrazione metadati da riga tabella HTML o title link."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Iterable
+
+from .names import row_to_filename, title_to_filename
+
+
+@dataclass
+class PortalRow:
+    tipo: str
+    numero: str
+    anno: str
+    corte: str
+    title: str | None = None
+
+    def to_meta(self) -> dict:
+        if self.title:
+            meta = title_to_filename(self.title)
+            if meta.get("ok"):
+                return meta
+        return row_to_filename(self.numero, self.anno, self.corte, self.tipo)
+
+
+class _TableParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.rows: list[list[str]] = []
+        self._in_td = False
+        self._current_row: list[str] | None = None
+        self._buf = ""
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "tr":
+            self._current_row = []
+        elif tag == "td" and self._current_row is not None:
+            self._in_td = True
+            self._buf = ""
+
+    def handle_endtag(self, tag):
+        if tag == "td" and self._in_td and self._current_row is not None:
+            self._current_row.append(self._buf.strip())
+            self._in_td = False
+        elif tag == "tr" and self._current_row is not None:
+            if self._current_row:
+                self.rows.append(self._current_row)
+            self._current_row = None
+
+    def handle_data(self, data):
+        if self._in_td:
+            self._buf += data
+
+
+def parse_table_html(html: str) -> list[PortalRow]:
+    parser = _TableParser()
+    parser.feed(html)
+    out: list[PortalRow] = []
+    for cells in parser.rows:
+        if len(cells) < 4:
+            continue
+        tipo, numero, anno, corte = cells[0], cells[1], cells[2], cells[3]
+        if not re.fullmatch(r"\d+", numero or ""):
+            continue
+        if not re.fullmatch(r"\d{4}", anno or ""):
+            continue
+        out.append(PortalRow(tipo=tipo, numero=numero, anno=anno, corte=corte))
+    return out
+
+
+def validate_row(row: PortalRow) -> list[str]:
+    errors: list[str] = []
+    if not row.numero:
+        errors.append("numero mancante")
+    if not row.anno:
+        errors.append("anno mancante")
+    if not row.corte:
+        errors.append("corte mancante")
+    meta = row.to_meta()
+    if not meta.get("ok"):
+        errors.append(meta.get("error") or "nome non calcolabile")
+    return errors
+
+
+def iter_validated(rows: Iterable[PortalRow]) -> list[tuple[PortalRow, dict, list[str]]]:
+    results = []
+    for row in rows:
+        errs = validate_row(row)
+        meta = row.to_meta() if not errs else {}
+        results.append((row, meta, errs))
+    return results

--- a/scripts/scraper_mef/portal_to_filename.py
+++ b/scripts/scraper_mef/portal_to_filename.py
@@ -93,6 +93,20 @@ def codice_to_corte_label(codice: str) -> dict | None:
     return None
 
 
+def normalize_tipo(tipo: str | None) -> str:
+    """Tipo provvedimento → token filename (Sentenza, Ordinanza, Decreto, ...)."""
+    raw = (tipo or "Sentenza").strip()
+    if not raw:
+        return "Sentenza"
+    # rimuovi caratteri non sicuri per nome file
+    cleaned = re.sub(r"[^\wÀ-ÿ]+", "_", raw, flags=re.UNICODE).strip("_")
+    if not cleaned:
+        return "Sentenza"
+    # Title-case semplice: Sentenza / Ordinanza
+    parts = [p for p in cleaned.split("_") if p]
+    return "_".join(p[:1].upper() + p[1:].lower() for p in parts)
+
+
 def build_filename(
     corte_portale: str,
     numero: str | int,
@@ -100,6 +114,7 @@ def build_filename(
     tipo: str = "Sentenza",
 ) -> dict:
     codice = corte_portale_to_codice(corte_portale)
+    tipo_norm = normalize_tipo(tipo)
     if not codice:
         return {
             "ok": False,
@@ -107,11 +122,12 @@ def build_filename(
             "cortePortale": corte_portale,
             "numero": str(numero),
             "anno": str(anno),
+            "tipo": tipo_norm,
         }
-    base = f"Sentenza_{codice}_{numero}_{anno}"
+    base = f"{tipo_norm}_{codice}_{numero}_{anno}"
     return {
         "ok": True,
-        "tipo": tipo,
+        "tipo": tipo_norm,
         "codice": codice,
         "numero": str(numero),
         "anno": str(anno),

--- a/scripts/scraper_mef/portal_to_filename.py
+++ b/scripts/scraper_mef/portal_to_filename.py
@@ -56,10 +56,14 @@ def _load_codici() -> None:
 
 
 def _normalize_place(place: str) -> str:
+    """Normalizza sede corte: spazi e trattini → underscore (Emilia-Romagna → EMILIA_ROMAGNA)."""
     text = (place or "").strip().upper()
     text = text.replace("Â°", "").replace("°", "")
     text = text.replace("'", "'").replace("'", "'")
-    return re.sub(r"\s+", "_", text)
+    text = text.replace("-", "_")
+    text = re.sub(r"\s+", "_", text)
+    text = re.sub(r"_+", "_", text)
+    return text.strip("_")
 
 
 def corte_portale_to_codice(corte_portale: str) -> str | None:

--- a/scripts/scraper_mef/portal_to_filename.py
+++ b/scripts/scraper_mef/portal_to_filename.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Portale MEF (2026) -> nome file SGAI standard.
+
+Il portale nuovo espone i dati in tabella HTML:
+  td[0] = tipo       (es. Sentenza)
+  td[1] = numero     (es. 1205)
+  td[2] = anno       (es. 2026)
+  td[3] = corte      (es. CGT 2° Lombardia)
+
+I link hanno title tipo:
+  Visualizza provvedimento n. 1205/2026 CGT 2° Lombardia
+
+Il PDF scaricato puo avere nome gibberish: usare sempre questi metadati
+per costruire il nome con cui noi salviamo i file:
+  Sentenza_V70_1205_2026.pdf
+
+Uso:
+  python portal_to_filename.py --corte "CGT 2° Lombardia" --numero 1205 --anno 2026
+  python portal_to_filename.py --title "Visualizza provvedimento n. 1205/2026 CGT 2° Lombardia"
+  python portal_to_filename.py --test-esempi
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+CODICI_PATH = Path(__file__).resolve().parent / "data" / "codici_corte.json"
+CODICI_CORTE: dict[str, str] = {}
+
+# Estrae "n. 1205/2026 CGT 2° Lombardia" da qualsiasi title portale 2026/legacy
+PORTAL_PROV_RE = re.compile(
+    r"n\.?\s*(\d+)\s*/\s*(\d{4})\s+CGT\s*(1|2)\s*[°º]?\s*(.+)$",
+    re.IGNORECASE,
+)
+
+# Esempi reali dal portale aggiornato (luglio 2026)
+ESEMPI_PORTALE = [
+    ("1205", "2026", "CGT 2° Lombardia", "V70", "Sentenza_V70_1205_2026.pdf"),
+    ("1489", "2026", "CGT 2° Puglia", "Z31", "Sentenza_Z31_1489_2026.pdf"),
+    ("2686", "2026", "CGT 2° Lazio", "Z18", "Sentenza_Z18_2686_2026.pdf"),
+    ("3338", "2026", "CGT 2° Sicilia", "Z46", "Sentenza_Z46_3338_2026.pdf"),
+    ("386", "2026", "CGT 1° Bologna", "U55", "Sentenza_U55_386_2026.pdf"),
+    ("13747", "2021", "CGT 1° Napoli", "V10", "Sentenza_V10_13747_2021.pdf"),
+]
+
+
+def _load_codici() -> None:
+    global CODICI_CORTE
+    if CODICI_CORTE:
+        return
+    data = json.loads(CODICI_PATH.read_text(encoding="utf-8"))
+    CODICI_CORTE = data.get("corteToCodice") or {}
+
+
+def _normalize_place(place: str) -> str:
+    text = (place or "").strip().upper()
+    text = text.replace("Â°", "").replace("°", "")
+    text = text.replace("'", "'").replace("'", "'")
+    return re.sub(r"\s+", "_", text)
+
+
+def corte_portale_to_codice(corte_portale: str) -> str | None:
+    """CGT 2° Lombardia -> V70, CGT 1° Bologna -> U55, ecc."""
+    _load_codici()
+    corte = (corte_portale or "").replace("Â°", "°").strip()
+    m = re.match(r"CGT\s*(1|2)[°º]?\s+(.+)", corte, re.IGNORECASE)
+    if not m:
+        return None
+    key = f"{m.group(1)}°_{_normalize_place(m.group(2))}"
+    if key in CODICI_CORTE:
+        return CODICI_CORTE[key]
+    for corte_key, codice in CODICI_CORTE.items():
+        if corte_key.upper() == key.upper():
+            return codice
+    return None
+
+
+def codice_to_corte_label(codice: str) -> dict | None:
+    _load_codici()
+    codice = (codice or "").upper()
+    for corte_key, code in CODICI_CORTE.items():
+        if code.upper() == codice:
+            grado, *rest = corte_key.split("_", 1)
+            return {
+                "codice": code,
+                "grado": grado,
+                "denominazione": rest[0].replace("_", " ") if rest else "",
+                "cortePortale": f"CGT {grado} {rest[0].replace('_', ' ') if rest else ''}".strip(),
+            }
+    return None
+
+
+def build_filename(
+    corte_portale: str,
+    numero: str | int,
+    anno: str | int,
+    tipo: str = "Sentenza",
+) -> dict:
+    codice = corte_portale_to_codice(corte_portale)
+    if not codice:
+        return {
+            "ok": False,
+            "error": f"Codice corte non trovato per: {corte_portale}",
+            "cortePortale": corte_portale,
+            "numero": str(numero),
+            "anno": str(anno),
+        }
+    base = f"Sentenza_{codice}_{numero}_{anno}"
+    return {
+        "ok": True,
+        "tipo": tipo,
+        "codice": codice,
+        "numero": str(numero),
+        "anno": str(anno),
+        "cortePortale": corte_portale,
+        "nomeBase": base,
+        "nomeFile": f"{base}.pdf",
+        "corte": codice_to_corte_label(codice),
+    }
+
+
+def parse_portal_title(title: str) -> dict | None:
+    """
+    Supporta title portale nuovo e legacy:
+      Visualizza provvedimento n. 1205/2026 CGT 2° Lombardia
+      Visualizza sommario automatico del provvedimento n. 1205/2026 CGT 2° Puglia
+      Scarica il pdf della sentenza n. 13747/2021 CGT 1° Napoli
+    """
+    raw = (title or "").strip()
+    if not raw:
+        return None
+    m = PORTAL_PROV_RE.search(raw)
+    if not m:
+        return None
+    numero, anno, grado, luogo = m.group(1), m.group(2), m.group(3), m.group(4).strip()
+    corte = f"CGT {grado}° {luogo}"
+    result = build_filename(corte, numero, anno)
+    result["portalTitle"] = raw
+    return result
+
+
+def parse_portal_row(
+    numero: str | int,
+    anno: str | int,
+    corte_portale: str,
+    tipo: str = "Sentenza",
+) -> dict:
+    """
+    Da riga tabella portale 2026:
+      celle: [tipo, numero, anno, corte, data, importo, ...]
+    """
+    return build_filename(corte_portale, numero, anno, tipo=tipo)
+
+
+def parse_portal_html_row(cells: list[str]) -> dict | None:
+    """cells = testi delle prime 4 td della riga tabella."""
+    if len(cells) < 4:
+        return None
+    tipo, numero, anno, corte = [c.strip() for c in cells[:4]]
+    if not numero or not anno or not corte:
+        return None
+    return parse_portal_row(numero, anno, corte, tipo=tipo or "Sentenza")
+
+
+def run_test_esempi() -> int:
+    ok = 0
+    fail = 0
+    print("Test mappatura portale -> nome file SGAI\n")
+    for numero, anno, corte, codice_atteso, file_atteso in ESEMPI_PORTALE:
+        result = build_filename(corte, numero, anno)
+        passed = (
+            result.get("ok")
+            and result.get("codice") == codice_atteso
+            and result.get("nomeFile") == file_atteso
+        )
+        status = "OK" if passed else "FAIL"
+        if passed:
+            ok += 1
+        else:
+            fail += 1
+        print(f"[{status}] {corte} n.{numero}/{anno}")
+        print(f"       atteso: {codice_atteso} -> {file_atteso}")
+        print(f"       ottenuto: {result.get('codice')} -> {result.get('nomeFile')}")
+        if not passed:
+            print(f"       errore: {result.get('error', '')}")
+        print()
+    print(f"Risultato: {ok} OK, {fail} FAIL")
+    return 0 if fail == 0 else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Portale MEF 2026 -> nome file SGAI")
+    parser.add_argument("--title", default="", help="Attributo title del link in tabella")
+    parser.add_argument("--corte", default="", help='Es. "CGT 2° Lombardia"')
+    parser.add_argument("--numero", default="")
+    parser.add_argument("--anno", default="")
+    parser.add_argument("--tipo", default="Sentenza")
+    parser.add_argument("--test-esempi", action="store_true", help="Verifica mappatura prefissi")
+    args = parser.parse_args()
+
+    if args.test_esempi:
+        return run_test_esempi()
+
+    if args.title:
+        result = parse_portal_title(args.title)
+        if not result:
+            print(json.dumps({"ok": False, "error": "Title non interpretabile"}, ensure_ascii=False))
+            return 1
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0 if result.get("ok") else 1
+
+    if args.corte and args.numero and args.anno:
+        result = build_filename(args.corte, args.numero, args.anno, tipo=args.tipo)
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0 if result.get("ok") else 1
+
+    parser.error("Specificare --title, oppure --corte --numero --anno, oppure --test-esempi")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scraper_mef/runner.py
+++ b/scripts/scraper_mef/runner.py
@@ -3,17 +3,22 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .cache import SkipIndex
 from .checkpoint import Checkpoint
-from .client import LiveMefClient, MefClient
+from .client import LiveMefClient, MefBlockedError, MefClient, MefHttpError
 from .config import Config
-from .download import cleanup_tmp_dir, ingest_pdf_bytes, make_minimal_pdf
+from .download import (
+    cleanup_tmp_dir,
+    coherence_nome_vs_meta,
+    ingest_pdf_bytes,
+    make_minimal_pdf,
+)
 from .limits import RunLimits
 from .logging_utils import setup_logger
 from .metrics import Metrics
-from .parse import PortalRow, iter_validated
+from .parse import PortalRow, metas_match, validate_row
 from .upload import UploadDisabledError, enqueue_upload
 
 log = setup_logger()
@@ -21,7 +26,231 @@ log = setup_logger()
 
 def _build_index(cfg: Config, output_dir: Path, server_caches: list[Path]) -> SkipIndex:
     files = list(server_caches) if server_caches else cfg.default_server_caches()
-    return SkipIndex(output_dir=output_dir, server_cache_files=files, embedded_files=files)
+    return SkipIndex(
+        output_dir=output_dir,
+        server_cache_files=files,
+        embedded_files=files,
+        min_pdf_bytes=cfg.min_pdf_bytes,
+        max_pdf_bytes=cfg.max_pdf_bytes,
+    )
+
+
+FetchFn = Callable[[PortalRow], tuple[bytes, dict | None]]
+
+
+def process_rows(
+    rows: list[PortalRow],
+    *,
+    index: SkipIndex,
+    checkpoint: Checkpoint,
+    metrics: Metrics,
+    limits: RunLimits,
+    cfg: Config,
+    output_dir: Path,
+    max_attempts: int,
+    page_number: int,
+    fetch_pdf: FetchFn,
+    require_detail_meta: bool = False,
+    resume: bool = True,
+) -> list[dict[str, Any]]:
+    """
+    Loop core testabile.
+    --max = max_attempts conta OGNI tentativo download (successo o fallimento),
+    non solo i PDF salvati. Skip A/B/C e invalid non consumano il budget.
+    """
+    results: list[dict[str, Any]] = []
+    max_attempts = max(1, int(max_attempts))
+    checkpoint.set_status("running")
+
+    for row in rows:
+        if limits.stop.should_stop:
+            checkpoint.set_status("stopped")
+            break
+        if metrics.attempts >= max_attempts:
+            break
+
+        row_index = int(row.row_index if row.row_index is not None else 0)
+        metrics.discovered += 1
+
+        errs = validate_row(row)
+        if errs:
+            metrics.skipped_invalid += 1
+            results.append({"action": "skip_invalid", "errors": errs, "row": row.__dict__})
+            # avanza posizione anche su invalid per non restare bloccati
+            checkpoint.set_position(page=page_number, row_index=row_index + 1)
+            continue
+
+        list_meta = row.to_meta()
+        nome_base = list_meta["nomeBase"]
+
+        if resume and checkpoint.is_done(nome_base):
+            metrics.skipped_checkpoint += 1
+            results.append(
+                {
+                    "action": "skip_checkpoint",
+                    "nomeBase": nome_base,
+                    "nomeFile": list_meta["nomeFile"],
+                }
+            )
+            checkpoint.set_position(page=page_number, row_index=row_index + 1)
+            continue
+
+        if resume and row_index < int(checkpoint.data.get("last_row_index") or 0):
+            # stessa pagina: già superata in run precedente
+            if int(checkpoint.data.get("last_page") or 0) == page_number:
+                metrics.skipped_checkpoint += 1
+                results.append(
+                    {
+                        "action": "skip_checkpoint_row",
+                        "row_index": row_index,
+                        "nomeBase": nome_base,
+                    }
+                )
+                continue
+
+        decision = index.decide(nome_base)
+        item: dict[str, Any] = {
+            **decision.to_dict(),
+            "nomeFile": list_meta["nomeFile"],
+            "nomeBase": nome_base,
+            "tipo": list_meta.get("tipo"),
+            "row_index": row_index,
+        }
+        if decision.action == "skip_local":
+            metrics.skipped_local += 1
+            results.append(item)
+            checkpoint.set_position(page=page_number, row_index=row_index + 1)
+            continue
+        if decision.action == "skip_server":
+            metrics.skipped_server += 1
+            results.append(item)
+            checkpoint.set_position(page=page_number, row_index=row_index + 1)
+            continue
+        if decision.action == "skip_embedded":
+            metrics.skipped_embedded += 1
+            results.append(item)
+            checkpoint.set_position(page=page_number, row_index=row_index + 1)
+            continue
+
+        if limits.stop.should_stop:
+            item["action"] = "stopped_before_download"
+            results.append(item)
+            checkpoint.set_status("stopped")
+            break
+
+        if metrics.attempts >= max_attempts:
+            item["action"] = "would_download_capped"
+            metrics.would_download += 1
+            results.append(item)
+            break
+
+        # --- tentativo download (conta sempre) ---
+        metrics.attempts += 1
+        item["attempt"] = metrics.attempts
+        dest = output_dir / list_meta["nomeFile"]
+        tmp = cfg.tmp_dir / f"{nome_base}.bin"
+
+        try:
+            with limits.download_slot():
+                log.info(
+                    "DOWNLOAD attempt=%s/%s %s",
+                    metrics.attempts,
+                    max_attempts,
+                    list_meta["nomeFile"],
+                )
+                data, detail_meta = fetch_pdf(row)
+
+            if require_detail_meta or detail_meta is not None:
+                if not detail_meta:
+                    raise RuntimeError("metadati dettaglio assenti")
+                mismatch = metas_match(list_meta, detail_meta)
+                if mismatch:
+                    raise RuntimeError("PDF-metadati disallineati: " + "; ".join(mismatch))
+                # nome canonico dal dettaglio (fonte autoritativa)
+                final_meta = detail_meta
+            else:
+                final_meta = list_meta
+
+            coh = coherence_nome_vs_meta(final_meta["nomeBase"], final_meta)
+            if coh:
+                raise RuntimeError("; ".join(coh))
+
+            dest = output_dir / final_meta["nomeFile"]
+            outcome = ingest_pdf_bytes(
+                data,
+                dest,
+                min_bytes=cfg.min_pdf_bytes,
+                max_bytes=cfg.max_pdf_bytes,
+                overwrite=decision.layer == "A_locale_corrupt",
+            )
+            if not outcome.get("ok"):
+                raise RuntimeError("PDF non valido: " + "; ".join(outcome.get("errors") or []))
+
+            metrics.downloaded += 1
+            checkpoint.mark_processed(
+                final_meta["nomeBase"], page=page_number, row_index=row_index + 1
+            )
+            index.server_keys.add(final_meta["nomeBase"].lower())
+            item.update(
+                {
+                    "action": "downloaded",
+                    "nomeFile": final_meta["nomeFile"],
+                    "nomeBase": final_meta["nomeBase"],
+                    "tipo": final_meta.get("tipo"),
+                    "sha256": outcome["sha256"],
+                    "size": outcome["size"],
+                    "path": outcome["path"],
+                    "detail_ok": True,
+                }
+            )
+            try:
+                enqueue_upload(dest, enabled=cfg.upload_enabled)
+                metrics.uploaded += 1
+            except UploadDisabledError:
+                item["upload"] = "disabled"
+            except NotImplementedError as exc:
+                item["upload"] = f"stub:{exc}"
+            results.append(item)
+            cleanup_tmp_dir(cfg.tmp_dir, keep_newest=20)
+            if metrics.attempts < max_attempts and not limits.stop.should_stop:
+                limits.pause_between_downloads(log=lambda m: log.info(m))
+
+        except MefBlockedError as exc:
+            metrics.errors += 1
+            metrics.blocked += 1
+            item.update(
+                {
+                    "action": "blocked",
+                    "error": str(exc)[:300],
+                    "http_status": exc.status,
+                }
+            )
+            results.append(item)
+            checkpoint.mark_failed(nome_base, page=page_number, row_index=row_index + 1)
+            checkpoint.set_status("blocked", block_reason=str(exc)[:300])
+            log.error("BLOCCATO (stop): %s", exc)
+            break
+
+        except (MefHttpError, Exception) as exc:
+            metrics.errors += 1
+            item.update({"action": "download_error", "error": str(exc)[:300]})
+            results.append(item)
+            checkpoint.mark_failed(nome_base, page=page_number, row_index=row_index + 1)
+            log.error("errore download: %s", exc)
+            # tentativo fallito consuma --max; continua finché budget
+            if metrics.attempts >= max_attempts:
+                break
+            if not limits.stop.should_stop:
+                limits.pause_between_downloads(log=lambda m: log.info(m))
+
+    if checkpoint.data.get("status") == "running":
+        if limits.stop.should_stop:
+            checkpoint.set_status("stopped")
+        elif metrics.blocked:
+            checkpoint.set_status("blocked")
+        else:
+            checkpoint.set_status("completed")
+    return results
 
 
 def run_scraper(
@@ -33,13 +262,15 @@ def run_scraper(
     output_dir: Path,
     server_caches: list[Path],
     cdp_url: str,
+    resume: bool = True,
 ) -> int:
     """
     mode:
-      - simulate: usa fixture + PDF sintetico (test pipeline/limiti, no portale)
+      - simulate: fixture + PDF sintetico (no portale)
       - live: CDP browser già aperto sulla pagina risultati MEF
+    max_downloads: budget TENTATIVI (non solo successi).
     """
-    max_downloads = max(1, int(max_downloads))
+    max_attempts = max(1, int(max_downloads))
     limits = RunLimits(
         max_download_concurrency=cfg.max_download_concurrency,
         delay_min=cfg.download_delay_min,
@@ -50,110 +281,25 @@ def run_scraper(
 
     index = _build_index(cfg, output_dir, server_caches)
     checkpoint = Checkpoint(cfg.checkpoint_path)
+    if not resume:
+        checkpoint.data["last_row_index"] = 0
+        checkpoint.data["last_page"] = 0
+        checkpoint.data["processed"] = []
+        checkpoint.data["failed"] = []
+        checkpoint.data["status"] = "idle"
+        checkpoint.data["block_reason"] = None
+        checkpoint.save()
+    elif checkpoint.data.get("status") == "completed":
+        # Nuova run: riparti dalla riga 0 ma conserva processed/failed (idempotenza)
+        checkpoint.data["last_row_index"] = 0
+        checkpoint.data["status"] = "idle"
+        checkpoint.data["block_reason"] = None
+        checkpoint.save()
+
     metrics = Metrics()
     cfg.tmp_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
-
     results: list[dict[str, Any]] = []
-    downloaded_now = 0
-
-    def handle_row(row: PortalRow, row_index: int | None, fetch_bytes) -> bool:
-        """True se ha raggiunto max_downloads."""
-        nonlocal downloaded_now
-        metrics.discovered += 1
-        errs = []
-        meta = {}
-        for r, m, e in iter_validated([row]):
-            errs, meta = e, m
-        if errs:
-            metrics.skipped_invalid += 1
-            results.append({"action": "skip_invalid", "errors": errs, "row": row.__dict__})
-            return False
-
-        decision = index.decide(meta["nomeBase"])
-        item = {
-            **decision.to_dict(),
-            "nomeFile": meta["nomeFile"],
-            "nomeBase": meta["nomeBase"],
-        }
-        if decision.action == "skip_local":
-            metrics.skipped_local += 1
-            results.append(item)
-            return False
-        if decision.action == "skip_server":
-            metrics.skipped_server += 1
-            results.append(item)
-            return False
-        if decision.action == "skip_embedded":
-            metrics.skipped_embedded += 1
-            results.append(item)
-            return False
-
-        if limits.stop.should_stop:
-            item["action"] = "stopped_before_download"
-            results.append(item)
-            return True
-
-        if downloaded_now >= max_downloads:
-            item["action"] = "would_download_capped"
-            metrics.would_download += 1
-            results.append(item)
-            return True
-
-        dest = output_dir / meta["nomeFile"]
-        tmp = cfg.tmp_dir / f"{meta['nomeBase']}.bin"
-        try:
-            with limits.download_slot():
-                log.info(
-                    "DOWNLOAD %s (mode=%s, slot concurrency=%s)",
-                    meta["nomeFile"],
-                    mode,
-                    limits.max_download_concurrency,
-                )
-                data = fetch_bytes(row_index)
-                outcome = ingest_pdf_bytes(
-                    data,
-                    dest,
-                    min_bytes=cfg.min_pdf_bytes,
-                    max_bytes=cfg.max_pdf_bytes,
-                )
-            if not outcome.get("ok"):
-                metrics.errors += 1
-                item.update({"action": "download_error", "errors": outcome.get("errors")})
-                results.append(item)
-                return False
-
-            metrics.downloaded += 1
-            downloaded_now += 1
-            checkpoint.mark_processed(meta["nomeBase"])
-            index.server_keys.add(meta["nomeBase"].lower())  # evita ridownload in-loop
-            item.update(
-                {
-                    "action": "downloaded",
-                    "sha256": outcome["sha256"],
-                    "size": outcome["size"],
-                    "path": outcome["path"],
-                }
-            )
-            # Upload sempre bloccato in Fase 2 salvo flag esplicito (non consigliato)
-            try:
-                enqueue_upload(dest, enabled=cfg.upload_enabled)
-                metrics.uploaded += 1
-            except UploadDisabledError:
-                item["upload"] = "disabled"
-            except NotImplementedError as exc:
-                item["upload"] = f"stub:{exc}"
-            results.append(item)
-            cleanup_tmp_dir(cfg.tmp_dir, keep_newest=20)
-            if downloaded_now < max_downloads and not limits.stop.should_stop:
-                limits.pause_between_downloads(log=lambda m: log.info(m))
-            return downloaded_now >= max_downloads
-        except Exception as exc:
-            metrics.errors += 1
-            item.update({"action": "download_error", "error": str(exc)[:300]})
-            results.append(item)
-            log.error("errore download: %s", exc)
-            return False
 
     if mode == "simulate":
         if not fixture or not fixture.exists():
@@ -161,41 +307,69 @@ def run_scraper(
             return 2
         rows = MefClient().rows_from_fixture(fixture)
         for i, row in enumerate(rows):
-            if limits.stop.should_stop:
-                break
-            done = handle_row(
-                row,
-                i,
-                fetch_bytes=lambda _idx: make_minimal_pdf(cfg.min_pdf_bytes),
-            )
-            if done:
-                break
+            if row.row_index is None:
+                row.row_index = i
+
+        def _fetch_sim(row: PortalRow) -> tuple[bytes, dict | None]:
+            # simulate: nessun dettaglio reale; meta lista usata come "detail"
+            return make_minimal_pdf(cfg.min_pdf_bytes), row.to_meta()
+
+        results = process_rows(
+            rows,
+            index=index,
+            checkpoint=checkpoint,
+            metrics=metrics,
+            limits=limits,
+            cfg=cfg,
+            output_dir=output_dir,
+            max_attempts=max_attempts,
+            page_number=int(checkpoint.data.get("last_page") or 1) or 1,
+            fetch_pdf=_fetch_sim,
+            require_detail_meta=False,
+            resume=resume,
+        )
+
     elif mode == "live":
         log.info("LIVE: connessione CDP %s (browser già aperto sulla lista risultati)", cdp_url)
         try:
             with LiveMefClient(cdp_url=cdp_url) as client:
                 rows = client.current_rows()
                 if not rows:
-                    log.error("Nessuna riga tabella sulla tab MEF — fai prima una Ricerca nel browser")
+                    log.error("Nessun link Visualizza sulla tab MEF — fai prima una Ricerca")
                     return 2
-                # mappa indice link ≈ indice riga valida
-                for i, row in enumerate(rows):
-                    if limits.stop.should_stop:
-                        break
+                page_number = client.current_page_number()
+                checkpoint.set_position(page=page_number)
 
-                    def _fetch(idx: int, _row=row) -> bytes:
-                        # trova indice Visualizza corrispondente: usa i
-                        return client.download_row_pdf(idx, cfg.tmp_dir / f"live_{idx}.pdf")
+                def _fetch_live(row: PortalRow) -> tuple[bytes, dict | None]:
+                    tmp = cfg.tmp_dir / f"live_{row.row_index or 0}.pdf"
+                    data, detail_meta = client.fetch_row_pdf(row, tmp)
+                    return data, detail_meta
 
-                    done = handle_row(row, i, fetch_bytes=_fetch)
-                    if done:
-                        break
+                results = process_rows(
+                    rows,
+                    index=index,
+                    checkpoint=checkpoint,
+                    metrics=metrics,
+                    limits=limits,
+                    cfg=cfg,
+                    output_dir=output_dir,
+                    max_attempts=max_attempts,
+                    page_number=page_number,
+                    fetch_pdf=_fetch_live,
+                    require_detail_meta=True,
+                    resume=resume,
+                )
+        except MefBlockedError as exc:
+            log.error("LIVE bloccato: %s", exc)
+            checkpoint.set_status("blocked", block_reason=str(exc)[:300])
+            return 3
         except Exception as exc:
             log.error("LIVE fallito: %s", exc)
             log.error(
                 "Avvia Edge/Opera con remote debugging (es. porta 9222) "
                 "e lascia aperta la pagina risultati MEF, poi riprova."
             )
+            checkpoint.set_status("error", block_reason=str(exc)[:300])
             return 2
     else:
         log.error("mode sconosciuta: %s", mode)
@@ -204,24 +378,40 @@ def run_scraper(
     payload = {
         "mode": mode,
         "limits": {
-            "max_downloads": max_downloads,
+            "max_attempts": max_attempts,
+            "note": "--max limita tutti i tentativi (successi + falliti), non solo i download ok",
             "download_concurrency": limits.max_download_concurrency,
             "delay_min": limits.delay_min,
             "delay_max": limits.delay_max,
             "page_delay": limits.page_delay,
             "upload_enabled": cfg.upload_enabled,
+            "pagination": "NOT_IMPLEMENTED",
+            "multi_worker": "NOT_IMPLEMENTED",
+            "sgai_upload": "DISABLED_STUB",
         },
         "output_dir": str(output_dir),
         "sources": index.sources,
+        "checkpoint": {
+            "path": str(checkpoint.path),
+            "last_page": checkpoint.data.get("last_page"),
+            "last_row_index": checkpoint.data.get("last_row_index"),
+            "last_document": checkpoint.data.get("last_document"),
+            "status": checkpoint.data.get("status"),
+            "block_reason": checkpoint.data.get("block_reason"),
+        },
         "metrics": metrics.as_dict(),
         "items": results,
         "stopped": limits.stop.should_stop,
     }
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     log.info(
-        "run fine: downloaded=%s errors=%s stop=%s",
+        "run fine: attempts=%s downloaded=%s errors=%s blocked=%s status=%s",
+        metrics.attempts,
         metrics.downloaded,
         metrics.errors,
-        limits.stop.should_stop,
+        metrics.blocked,
+        checkpoint.data.get("status"),
     )
+    if metrics.blocked:
+        return 3
     return 0 if metrics.errors == 0 else 1

--- a/scripts/scraper_mef/runner.py
+++ b/scripts/scraper_mef/runner.py
@@ -59,7 +59,11 @@ def process_rows(
     non solo i PDF salvati. Skip A/B/C e invalid non consumano il budget.
     """
     results: list[dict[str, Any]] = []
-    max_attempts = max(1, int(max_attempts))
+    max_attempts = int(max_attempts)
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts deve essere >= 1 (ricevuto {max_attempts})")
+    # Allinea pagina: se è cambiata rispetto al checkpoint, azzera last_row_index
+    checkpoint.sync_page(page_number)
     checkpoint.set_status("running")
 
     for row in rows:
@@ -84,20 +88,38 @@ def process_rows(
         nome_base = list_meta["nomeBase"]
 
         if resume and checkpoint.is_done(nome_base):
-            metrics.skipped_checkpoint += 1
+            # Skip solo se PDF locale ancora valido OPPURE cache server autorevole.
+            # Altrimenti invalida processed/failed e riscarica (file cancellato/corrotto).
+            local_ok = index.is_local(nome_base)
+            server_ok = index.is_server(nome_base) or index.is_embedded(nome_base)
+            if local_ok or server_ok:
+                metrics.skipped_checkpoint += 1
+                results.append(
+                    {
+                        "action": "skip_checkpoint",
+                        "nomeBase": nome_base,
+                        "nomeFile": list_meta["nomeFile"],
+                        "reason": "local_valid" if local_ok else "server_authoritative",
+                    }
+                )
+                checkpoint.set_position(page=page_number, row_index=row_index + 1)
+                continue
+            checkpoint.invalidate_done(nome_base)
             results.append(
                 {
-                    "action": "skip_checkpoint",
+                    "action": "checkpoint_invalidated",
                     "nomeBase": nome_base,
-                    "nomeFile": list_meta["nomeFile"],
+                    "detail": "processed/failed senza PDF locale valido né conferma server",
                 }
             )
-            checkpoint.set_position(page=page_number, row_index=row_index + 1)
-            continue
 
         if resume and row_index < int(checkpoint.data.get("last_row_index") or 0):
-            # stessa pagina: già superata in run precedente
-            if int(checkpoint.data.get("last_page") or 0) == page_number:
+            # stessa pagina: salta solo se il doc è ancora "done" (local/server ok).
+            # Se invalidato (PDF mancante/corrotto) deve essere riprocessato.
+            if (
+                int(checkpoint.data.get("last_page") or 0) == page_number
+                and checkpoint.is_done(nome_base)
+            ):
                 metrics.skipped_checkpoint += 1
                 results.append(
                     {
@@ -218,17 +240,18 @@ def process_rows(
         except MefBlockedError as exc:
             metrics.errors += 1
             metrics.blocked += 1
+            reason = f"HTTP {exc.status}: {exc}"[:300]
             item.update(
                 {
                     "action": "blocked",
-                    "error": str(exc)[:300],
+                    "error": reason,
                     "http_status": exc.status,
                 }
             )
             results.append(item)
             checkpoint.mark_failed(nome_base, page=page_number, row_index=row_index + 1)
-            checkpoint.set_status("blocked", block_reason=str(exc)[:300])
-            log.error("BLOCCATO (stop): %s", exc)
+            checkpoint.set_status("blocked", block_reason=reason)
+            log.error("BLOCCATO (stop): %s", reason)
             break
 
         except (MefHttpError, Exception) as exc:
@@ -268,9 +291,12 @@ def run_scraper(
     mode:
       - simulate: fixture + PDF sintetico (no portale)
       - live: CDP browser già aperto sulla pagina risultati MEF
-    max_downloads: budget TENTATIVI (non solo successi).
+    max_downloads: budget TENTATIVI (non solo successi). --max 0 → errore.
     """
-    max_attempts = max(1, int(max_downloads))
+    max_attempts = int(max_downloads)
+    if max_attempts < 1:
+        log.error("--max deve essere >= 1 (ricevuto %s); nessun tentativo", max_downloads)
+        return 2
     limits = RunLimits(
         max_download_concurrency=cfg.max_download_concurrency,
         delay_min=cfg.download_delay_min,
@@ -338,7 +364,8 @@ def run_scraper(
                     log.error("Nessun link Visualizza sulla tab MEF — fai prima una Ricerca")
                     return 2
                 page_number = client.current_page_number()
-                checkpoint.set_position(page=page_number)
+                # Se la pagina live è diversa da quella nel checkpoint, azzera le righe
+                checkpoint.sync_page(page_number)
 
                 def _fetch_live(row: PortalRow) -> tuple[bytes, dict | None]:
                     tmp = cfg.tmp_dir / f"live_{row.row_index or 0}.pdf"

--- a/scripts/scraper_mef/runner.py
+++ b/scripts/scraper_mef/runner.py
@@ -1,0 +1,227 @@
+"""Orchestrazione comando `run` (Fase 2): skip A/B/C + download limitato, no upload."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .cache import SkipIndex
+from .checkpoint import Checkpoint
+from .client import LiveMefClient, MefClient
+from .config import Config
+from .download import cleanup_tmp_dir, ingest_pdf_bytes, make_minimal_pdf
+from .limits import RunLimits
+from .logging_utils import setup_logger
+from .metrics import Metrics
+from .parse import PortalRow, iter_validated
+from .upload import UploadDisabledError, enqueue_upload
+
+log = setup_logger()
+
+
+def _build_index(cfg: Config, output_dir: Path, server_caches: list[Path]) -> SkipIndex:
+    files = list(server_caches) if server_caches else cfg.default_server_caches()
+    return SkipIndex(output_dir=output_dir, server_cache_files=files, embedded_files=files)
+
+
+def run_scraper(
+    *,
+    cfg: Config,
+    mode: str,
+    max_downloads: int,
+    fixture: Path | None,
+    output_dir: Path,
+    server_caches: list[Path],
+    cdp_url: str,
+) -> int:
+    """
+    mode:
+      - simulate: usa fixture + PDF sintetico (test pipeline/limiti, no portale)
+      - live: CDP browser già aperto sulla pagina risultati MEF
+    """
+    max_downloads = max(1, int(max_downloads))
+    limits = RunLimits(
+        max_download_concurrency=cfg.max_download_concurrency,
+        delay_min=cfg.download_delay_min,
+        delay_max=cfg.download_delay_max,
+        page_delay=cfg.page_delay_sec,
+    )
+    limits.stop.install_signals()
+
+    index = _build_index(cfg, output_dir, server_caches)
+    checkpoint = Checkpoint(cfg.checkpoint_path)
+    metrics = Metrics()
+    cfg.tmp_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict[str, Any]] = []
+    downloaded_now = 0
+
+    def handle_row(row: PortalRow, row_index: int | None, fetch_bytes) -> bool:
+        """True se ha raggiunto max_downloads."""
+        nonlocal downloaded_now
+        metrics.discovered += 1
+        errs = []
+        meta = {}
+        for r, m, e in iter_validated([row]):
+            errs, meta = e, m
+        if errs:
+            metrics.skipped_invalid += 1
+            results.append({"action": "skip_invalid", "errors": errs, "row": row.__dict__})
+            return False
+
+        decision = index.decide(meta["nomeBase"])
+        item = {
+            **decision.to_dict(),
+            "nomeFile": meta["nomeFile"],
+            "nomeBase": meta["nomeBase"],
+        }
+        if decision.action == "skip_local":
+            metrics.skipped_local += 1
+            results.append(item)
+            return False
+        if decision.action == "skip_server":
+            metrics.skipped_server += 1
+            results.append(item)
+            return False
+        if decision.action == "skip_embedded":
+            metrics.skipped_embedded += 1
+            results.append(item)
+            return False
+
+        if limits.stop.should_stop:
+            item["action"] = "stopped_before_download"
+            results.append(item)
+            return True
+
+        if downloaded_now >= max_downloads:
+            item["action"] = "would_download_capped"
+            metrics.would_download += 1
+            results.append(item)
+            return True
+
+        dest = output_dir / meta["nomeFile"]
+        tmp = cfg.tmp_dir / f"{meta['nomeBase']}.bin"
+        try:
+            with limits.download_slot():
+                log.info(
+                    "DOWNLOAD %s (mode=%s, slot concurrency=%s)",
+                    meta["nomeFile"],
+                    mode,
+                    limits.max_download_concurrency,
+                )
+                data = fetch_bytes(row_index)
+                outcome = ingest_pdf_bytes(
+                    data,
+                    dest,
+                    min_bytes=cfg.min_pdf_bytes,
+                    max_bytes=cfg.max_pdf_bytes,
+                )
+            if not outcome.get("ok"):
+                metrics.errors += 1
+                item.update({"action": "download_error", "errors": outcome.get("errors")})
+                results.append(item)
+                return False
+
+            metrics.downloaded += 1
+            downloaded_now += 1
+            checkpoint.mark_processed(meta["nomeBase"])
+            index.server_keys.add(meta["nomeBase"].lower())  # evita ridownload in-loop
+            item.update(
+                {
+                    "action": "downloaded",
+                    "sha256": outcome["sha256"],
+                    "size": outcome["size"],
+                    "path": outcome["path"],
+                }
+            )
+            # Upload sempre bloccato in Fase 2 salvo flag esplicito (non consigliato)
+            try:
+                enqueue_upload(dest, enabled=cfg.upload_enabled)
+                metrics.uploaded += 1
+            except UploadDisabledError:
+                item["upload"] = "disabled"
+            except NotImplementedError as exc:
+                item["upload"] = f"stub:{exc}"
+            results.append(item)
+            cleanup_tmp_dir(cfg.tmp_dir, keep_newest=20)
+            if downloaded_now < max_downloads and not limits.stop.should_stop:
+                limits.pause_between_downloads(log=lambda m: log.info(m))
+            return downloaded_now >= max_downloads
+        except Exception as exc:
+            metrics.errors += 1
+            item.update({"action": "download_error", "error": str(exc)[:300]})
+            results.append(item)
+            log.error("errore download: %s", exc)
+            return False
+
+    if mode == "simulate":
+        if not fixture or not fixture.exists():
+            log.error("simulate richiede --fixture esistente")
+            return 2
+        rows = MefClient().rows_from_fixture(fixture)
+        for i, row in enumerate(rows):
+            if limits.stop.should_stop:
+                break
+            done = handle_row(
+                row,
+                i,
+                fetch_bytes=lambda _idx: make_minimal_pdf(cfg.min_pdf_bytes),
+            )
+            if done:
+                break
+    elif mode == "live":
+        log.info("LIVE: connessione CDP %s (browser già aperto sulla lista risultati)", cdp_url)
+        try:
+            with LiveMefClient(cdp_url=cdp_url) as client:
+                rows = client.current_rows()
+                if not rows:
+                    log.error("Nessuna riga tabella sulla tab MEF — fai prima una Ricerca nel browser")
+                    return 2
+                # mappa indice link ≈ indice riga valida
+                for i, row in enumerate(rows):
+                    if limits.stop.should_stop:
+                        break
+
+                    def _fetch(idx: int, _row=row) -> bytes:
+                        # trova indice Visualizza corrispondente: usa i
+                        return client.download_row_pdf(idx, cfg.tmp_dir / f"live_{idx}.pdf")
+
+                    done = handle_row(row, i, fetch_bytes=_fetch)
+                    if done:
+                        break
+        except Exception as exc:
+            log.error("LIVE fallito: %s", exc)
+            log.error(
+                "Avvia Edge/Opera con remote debugging (es. porta 9222) "
+                "e lascia aperta la pagina risultati MEF, poi riprova."
+            )
+            return 2
+    else:
+        log.error("mode sconosciuta: %s", mode)
+        return 2
+
+    payload = {
+        "mode": mode,
+        "limits": {
+            "max_downloads": max_downloads,
+            "download_concurrency": limits.max_download_concurrency,
+            "delay_min": limits.delay_min,
+            "delay_max": limits.delay_max,
+            "page_delay": limits.page_delay,
+            "upload_enabled": cfg.upload_enabled,
+        },
+        "output_dir": str(output_dir),
+        "sources": index.sources,
+        "metrics": metrics.as_dict(),
+        "items": results,
+        "stopped": limits.stop.should_stop,
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    log.info(
+        "run fine: downloaded=%s errors=%s stop=%s",
+        metrics.downloaded,
+        metrics.errors,
+        limits.stop.should_stop,
+    )
+    return 0 if metrics.errors == 0 else 1

--- a/scripts/scraper_mef/tests/test_cache_skip.py
+++ b/scripts/scraper_mef/tests/test_cache_skip.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT.parent))
+
+from scraper_mef.cache import NameCache, SkipIndex  # noqa: E402
+
+
+class TestCache(unittest.TestCase):
+    def test_embedded_skip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "cache.txt"
+            p.write_text("Sentenza_V10_13747_2021|embedded\n", encoding="utf-8")
+            cache = NameCache(p)
+            self.assertTrue(cache.should_skip("Sentenza_V10_13747_2021"))
+            self.assertFalse(cache.should_skip("Sentenza_V70_1205_2026"))
+
+    def test_three_layers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out"
+            out.mkdir()
+            (out / "Sentenza_V70_100_2025.pdf").write_bytes(b"%PDF-1.4 test")
+            server = Path(tmp) / "server.txt"
+            server.write_text("Sentenza_U91_6086_2025\n", encoding="utf-8")
+            idx = SkipIndex(output_dir=out, server_cache_files=[server])
+            self.assertEqual(idx.decide("Sentenza_V70_100_2025").action, "skip_local")
+            self.assertEqual(idx.decide("Sentenza_U91_6086_2025").action, "skip_server")
+            self.assertEqual(idx.decide("Sentenza_V70_1205_2026").action, "would_download")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/scraper_mef/tests/test_cache_skip.py
+++ b/scripts/scraper_mef/tests/test_cache_skip.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT.parent))
 
 from scraper_mef.cache import NameCache, SkipIndex  # noqa: E402
+from scraper_mef.download import make_minimal_pdf  # noqa: E402
 
 
 class TestCache(unittest.TestCase):
@@ -18,17 +19,32 @@ class TestCache(unittest.TestCase):
             self.assertTrue(cache.should_skip("Sentenza_V10_13747_2021"))
             self.assertFalse(cache.should_skip("Sentenza_V70_1205_2026"))
 
-    def test_three_layers(self):
+    def test_three_layers_valid_local(self):
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp) / "out"
             out.mkdir()
-            (out / "Sentenza_V70_100_2025.pdf").write_bytes(b"%PDF-1.4 test")
+            (out / "Sentenza_V70_100_2025.pdf").write_bytes(make_minimal_pdf(1200))
             server = Path(tmp) / "server.txt"
             server.write_text("Sentenza_U91_6086_2025\n", encoding="utf-8")
-            idx = SkipIndex(output_dir=out, server_cache_files=[server])
+            idx = SkipIndex(
+                output_dir=out,
+                server_cache_files=[server],
+                min_pdf_bytes=1000,
+                max_pdf_bytes=80_000_000,
+            )
             self.assertEqual(idx.decide("Sentenza_V70_100_2025").action, "skip_local")
             self.assertEqual(idx.decide("Sentenza_U91_6086_2025").action, "skip_server")
             self.assertEqual(idx.decide("Sentenza_V70_1205_2026").action, "would_download")
+
+    def test_corrupt_local_does_not_skip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "out"
+            out.mkdir()
+            (out / "Sentenza_V70_100_2025.pdf").write_bytes(b"")  # vuoto
+            idx = SkipIndex(output_dir=out, min_pdf_bytes=1000, max_pdf_bytes=80_000_000)
+            d = idx.decide("Sentenza_V70_100_2025")
+            self.assertEqual(d.action, "would_download")
+            self.assertEqual(d.layer, "A_locale_corrupt")
 
 
 if __name__ == "__main__":

--- a/scripts/scraper_mef/tests/test_checkpoint.py
+++ b/scripts/scraper_mef/tests/test_checkpoint.py
@@ -33,6 +33,19 @@ class TestCheckpoint(unittest.TestCase):
             self.assertEqual(cp2.data["status"], "blocked")
             self.assertEqual(cp2.data["block_reason"], "HTTP 429")
 
+    def test_sync_page_resets_row_index_on_page_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "cp.json"
+            cp = Checkpoint(path)
+            cp.set_position(page=1, row_index=7)
+            cp.sync_page(2)
+            self.assertEqual(cp.data["last_page"], 2)
+            self.assertEqual(cp.data["last_row_index"], 0)
+            # stessa pagina: non azzera
+            cp.set_position(row_index=3)
+            cp.sync_page(2)
+            self.assertEqual(cp.data["last_row_index"], 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/scraper_mef/tests/test_checkpoint.py
+++ b/scripts/scraper_mef/tests/test_checkpoint.py
@@ -10,15 +10,28 @@ from scraper_mef.checkpoint import Checkpoint  # noqa: E402
 
 
 class TestCheckpoint(unittest.TestCase):
-    def test_atomic_resume(self):
+    def test_atomic_resume_position(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "cp.json"
             cp = Checkpoint(path)
-            cp.set_page(12)
-            cp.mark_processed("Sentenza_V70_1205_2026")
+            cp.set_position(page=12, row_index=3)
+            cp.mark_processed("Sentenza_V70_1205_2026", page=12, row_index=4)
             cp2 = Checkpoint(path)
             self.assertEqual(cp2.data["last_page"], 12)
+            self.assertEqual(cp2.data["last_row_index"], 4)
             self.assertIn("Sentenza_V70_1205_2026", cp2.data["processed"])
+            self.assertTrue(cp2.is_done("Sentenza_V70_1205_2026"))
+
+    def test_failed_and_blocked_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "cp.json"
+            cp = Checkpoint(path)
+            cp.mark_failed("Sentenza_V70_1_2026", page=1, row_index=2)
+            cp.set_status("blocked", block_reason="HTTP 429")
+            cp2 = Checkpoint(path)
+            self.assertIn("Sentenza_V70_1_2026", cp2.data["failed"])
+            self.assertEqual(cp2.data["status"], "blocked")
+            self.assertEqual(cp2.data["block_reason"], "HTTP 429")
 
 
 if __name__ == "__main__":

--- a/scripts/scraper_mef/tests/test_checkpoint.py
+++ b/scripts/scraper_mef/tests/test_checkpoint.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT.parent))
+
+from scraper_mef.checkpoint import Checkpoint  # noqa: E402
+
+
+class TestCheckpoint(unittest.TestCase):
+    def test_atomic_resume(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "cp.json"
+            cp = Checkpoint(path)
+            cp.set_page(12)
+            cp.mark_processed("Sentenza_V70_1205_2026")
+            cp2 = Checkpoint(path)
+            self.assertEqual(cp2.data["last_page"], 12)
+            self.assertIn("Sentenza_V70_1205_2026", cp2.data["processed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/scraper_mef/tests/test_download_validate.py
+++ b/scripts/scraper_mef/tests/test_download_validate.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT.parent))
+
+from scraper_mef.download import (  # noqa: E402
+    coherence_nome_vs_meta,
+    ingest_pdf_bytes,
+    make_minimal_pdf,
+    validate_local_pdf,
+    verify_pdf,
+)
+
+
+class TestDownloadValidate(unittest.TestCase):
+    def test_html_as_pdf_rejected(self):
+        data = b"<!DOCTYPE html><html><body>nope</body></html>"
+        errs = verify_pdf(data, min_bytes=10, max_bytes=1_000_000)
+        self.assertTrue(any("HTML" in e for e in errs))
+
+    def test_truncated_pdf_no_eof(self):
+        data = b"%PDF-1.4\n1 0 obj<<>>endobj\n"
+        data = data + b"0" * 1200
+        errs = verify_pdf(data, min_bytes=1000, max_bytes=1_000_000)
+        self.assertTrue(any("EOF" in e for e in errs))
+
+    def test_valid_minimal(self):
+        data = make_minimal_pdf(1200)
+        self.assertEqual(verify_pdf(data, min_bytes=1000, max_bytes=1_000_000), [])
+
+    def test_local_empty_and_html(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "a.pdf"
+            empty.write_bytes(b"")
+            self.assertTrue(validate_local_pdf(empty, min_bytes=1000, max_bytes=1_000_000))
+
+            html = Path(tmp) / "b.pdf"
+            html.write_bytes(b"<html>x</html>" + b"0" * 1200)
+            errs = validate_local_pdf(html, min_bytes=1000, max_bytes=1_000_000)
+            self.assertTrue(any("HTML" in e or "firma" in e for e in errs))
+
+    def test_ingest_and_coherence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "Sentenza_V70_1205_2026.pdf"
+            out = ingest_pdf_bytes(
+                make_minimal_pdf(1200), dest, min_bytes=1000, max_bytes=1_000_000
+            )
+            self.assertTrue(out["ok"])
+            self.assertTrue(out["sha256"])
+            meta = {
+                "tipo": "Sentenza",
+                "codice": "V70",
+                "numero": "1205",
+                "anno": "2026",
+            }
+            self.assertEqual(coherence_nome_vs_meta("Sentenza_V70_1205_2026", meta), [])
+            self.assertTrue(
+                coherence_nome_vs_meta("Sentenza_V70_999_2026", meta)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/scraper_mef/tests/test_download_validate.py
+++ b/scripts/scraper_mef/tests/test_download_validate.py
@@ -12,6 +12,7 @@ from scraper_mef.download import (  # noqa: E402
     make_minimal_pdf,
     validate_local_pdf,
     verify_pdf,
+    verify_pdf_structure,
 )
 
 
@@ -30,6 +31,19 @@ class TestDownloadValidate(unittest.TestCase):
     def test_valid_minimal(self):
         data = make_minimal_pdf(1200)
         self.assertEqual(verify_pdf(data, min_bytes=1000, max_bytes=1_000_000), [])
+
+    def test_fake_pdf_header_eof_rejected_by_parser(self):
+        """%PDF- + %%EOF non bastano: payload non strutturato deve fallire."""
+        fake = b"%PDF-1.4\n" + (b"NOT_A_REAL_PDF_OBJECT\n" * 80) + b"%%EOF\n"
+        self.assertGreaterEqual(len(fake), 1000)
+        errs = verify_pdf(fake, min_bytes=1000, max_bytes=1_000_000)
+        self.assertTrue(errs, "fake PDF avrebbe dovuto fallire")
+        self.assertTrue(
+            any("parser" in e.lower() or "trailer" in e.lower() or "catalogo" in e.lower() for e in errs),
+            errs,
+        )
+        # anche il solo check strutturale
+        self.assertTrue(verify_pdf_structure(fake))
 
     def test_local_empty_and_html(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/scraper_mef/tests/test_parse_names.py
+++ b/scripts/scraper_mef/tests/test_parse_names.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT.parent))
+
+from scraper_mef.names import row_to_filename  # noqa: E402
+from scraper_mef.parse import parse_table_html  # noqa: E402
+
+
+class TestNames(unittest.TestCase):
+    def test_lombardia(self):
+        meta = row_to_filename("1205", "2026", "CGT 2° Lombardia")
+        self.assertTrue(meta["ok"])
+        self.assertEqual(meta["nomeFile"], "Sentenza_V70_1205_2026.pdf")
+
+    def test_fixture_rows(self):
+        html = (ROOT / "fixtures" / "sample_rows.html").read_text(encoding="utf-8")
+        rows = parse_table_html(html)
+        self.assertGreaterEqual(len(rows), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/scraper_mef/tests/test_parse_names.py
+++ b/scripts/scraper_mef/tests/test_parse_names.py
@@ -6,7 +6,15 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT.parent))
 
 from scraper_mef.names import row_to_filename  # noqa: E402
-from scraper_mef.parse import parse_table_html  # noqa: E402
+from scraper_mef.parse import (  # noqa: E402
+    PortalRow,
+    metas_match,
+    parse_detail_text,
+    parse_table_html,
+    rows_from_link_dicts,
+    validate_row,
+)
+from scraper_mef.portal_to_filename import normalize_tipo  # noqa: E402
 
 
 class TestNames(unittest.TestCase):
@@ -15,10 +23,68 @@ class TestNames(unittest.TestCase):
         self.assertTrue(meta["ok"])
         self.assertEqual(meta["nomeFile"], "Sentenza_V70_1205_2026.pdf")
 
+    def test_ordinanza_tipo(self):
+        meta = row_to_filename("1205", "2026", "CGT 2° Lombardia", tipo="Ordinanza")
+        self.assertTrue(meta["ok"])
+        self.assertEqual(meta["tipo"], "Ordinanza")
+        self.assertEqual(meta["nomeFile"], "Ordinanza_V70_1205_2026.pdf")
+        self.assertEqual(normalize_tipo("ordinanza"), "Ordinanza")
+
     def test_fixture_rows(self):
         html = (ROOT / "fixtures" / "sample_rows.html").read_text(encoding="utf-8")
         rows = parse_table_html(html)
         self.assertGreaterEqual(len(rows), 3)
+
+    def test_incomplete_row(self):
+        row = PortalRow(tipo="Sentenza", numero="", anno="2026", corte="CGT 2° Lombardia")
+        errs = validate_row(row)
+        self.assertTrue(any("numero" in e for e in errs))
+
+    def test_link_dict_association_not_filtered_index(self):
+        """Link i-esimo resta legato alla sua tr, anche se una riga tabellare è spazzatura."""
+        items = [
+            {
+                "row_index": 0,
+                "href": "/ricerca/dettaglio/aaa",
+                "title": "Visualizza provvedimento n. 1/2026 CGT 2° Lombardia",
+                "tipo": "Sentenza",
+                "numero": "1",
+                "anno": "2026",
+                "corte": "CGT 2° Lombardia",
+                "cells": ["Sentenza", "1", "2026", "CGT 2° Lombardia"],
+            },
+            {
+                "row_index": 1,
+                "href": "/ricerca/dettaglio/bbb",
+                "title": "Visualizza provvedimento n. 99/2026 CGT 2° Puglia",
+                "tipo": "Ordinanza",
+                "numero": "99",
+                "anno": "2026",
+                "corte": "CGT 2° Puglia",
+                "cells": ["Ordinanza", "99", "2026", "CGT 2° Puglia"],
+            },
+        ]
+        rows = rows_from_link_dicts(items)
+        self.assertEqual(rows[1].href, "/ricerca/dettaglio/bbb")
+        self.assertEqual(rows[1].to_meta()["nomeFile"], "Ordinanza_Z31_99_2026.pdf")
+
+    def test_detail_meta_and_mismatch(self):
+        detail_html = """
+        <html><body>
+        <h1>Sentenza n. 1205/2026 CGT 2° Lombardia</h1>
+        </body></html>
+        """
+        detail = parse_detail_text(detail_html, page_url="/ricerca/dettaglio/x")
+        self.assertTrue(detail["ok"])
+        self.assertEqual(detail["numero"], "1205")
+        self.assertEqual(detail["codice"], "V70")
+
+        list_meta = row_to_filename("999", "2026", "CGT 2° Lombardia")
+        mismatch = metas_match(list_meta, detail)
+        self.assertTrue(any("numero" in e for e in mismatch))
+
+        list_ok = row_to_filename("1205", "2026", "CGT 2° Lombardia")
+        self.assertEqual(metas_match(list_ok, detail), [])
 
 
 if __name__ == "__main__":

--- a/scripts/scraper_mef/tests/test_parse_names.py
+++ b/scripts/scraper_mef/tests/test_parse_names.py
@@ -30,6 +30,24 @@ class TestNames(unittest.TestCase):
         self.assertEqual(meta["nomeFile"], "Ordinanza_V70_1205_2026.pdf")
         self.assertEqual(normalize_tipo("ordinanza"), "Ordinanza")
 
+    def test_corte_con_trattino(self):
+        emilia = row_to_filename("100", "2026", "CGT 2° Emilia-Romagna")
+        self.assertTrue(emilia["ok"], emilia)
+        self.assertEqual(emilia["codice"], "V92")
+        self.assertEqual(emilia["nomeFile"], "Sentenza_V92_100_2026.pdf")
+
+        trentino = row_to_filename("200", "2026", "CGT 2° Trentino-Alto Adige")
+        self.assertTrue(trentino["ok"], trentino)
+        self.assertEqual(trentino["codice"], "V75")
+        self.assertEqual(trentino["nomeFile"], "Sentenza_V75_200_2026.pdf")
+
+        detail = parse_detail_text(
+            "Ordinanza n. 100/2026 CGT 2° Emilia-Romagna",
+            page_url="/ricerca/dettaglio/x",
+        )
+        self.assertTrue(detail["ok"], detail)
+        self.assertEqual(detail["codice"], "V92")
+
     def test_fixture_rows(self):
         html = (ROOT / "fixtures" / "sample_rows.html").read_text(encoding="utf-8")
         rows = parse_table_html(html)

--- a/scripts/scraper_mef/tests/test_runner_gate2.py
+++ b/scripts/scraper_mef/tests/test_runner_gate2.py
@@ -205,6 +205,104 @@ class TestRunnerGate2(unittest.TestCase):
             self.assertEqual(metrics.attempts, 1)
             self.assertEqual(cp.data["status"], "blocked")
 
+    def test_blocked_429_stops(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(
+                ("Sentenza", "1", "2026", "CGT 2° Lombardia"),
+                ("Sentenza", "2", "2026", "CGT 2° Lombardia"),
+            )
+
+            def fetch_429(row: PortalRow):
+                raise MefBlockedError(429, "too many requests")
+
+            metrics = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=5,
+                page_number=1,
+                fetch_pdf=fetch_429,
+                resume=False,
+            )
+            self.assertEqual(metrics.blocked, 1)
+            self.assertEqual(metrics.attempts, 1)
+            self.assertEqual(cp.data["status"], "blocked")
+            self.assertIn("429", str(cp.data.get("block_reason") or ""))
+
+    def test_processed_missing_pdf_is_redownloaded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(("Sentenza", "77", "2026", "CGT 2° Lombardia"))
+            nome = "Sentenza_V70_77_2026"
+            cp.mark_processed(nome, page=1, row_index=1)
+            # nessun PDF in out → deve invalidare e riscaricare
+            calls = {"n": 0}
+
+            def fetch(row: PortalRow):
+                calls["n"] += 1
+                return make_minimal_pdf(1200), row.to_meta()
+
+            metrics = Metrics()
+            items = process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=1,
+                page_number=1,
+                fetch_pdf=fetch,
+                resume=True,
+            )
+            self.assertEqual(calls["n"], 1)
+            self.assertEqual(metrics.downloaded, 1)
+            self.assertTrue(any(i.get("action") == "checkpoint_invalidated" for i in items))
+            self.assertTrue((out / f"{nome}.pdf").exists())
+
+    def test_page_change_resets_row_skip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            cp.set_position(page=1, row_index=5)
+            rows = _rows(
+                ("Sentenza", "1", "2026", "CGT 2° Lombardia"),
+                ("Sentenza", "2", "2026", "CGT 2° Lombardia"),
+            )
+
+            def fetch(row: PortalRow):
+                return make_minimal_pdf(1200), row.to_meta()
+
+            metrics = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=2,
+                page_number=2,  # pagina nuova
+                fetch_pdf=fetch,
+                resume=True,
+            )
+            self.assertEqual(cp.data["last_page"], 2)
+            self.assertEqual(metrics.downloaded, 2)
+            self.assertEqual(metrics.skipped_checkpoint, 0)
+
+    def test_max_zero_rejected(self):
+        from scraper_mef.cli import main
+
+        code = main(["run", "--max", "0", "--simulate"])
+        self.assertEqual(code, 2)
+
     def test_http_500_counts_attempt_continues(self):
         with tempfile.TemporaryDirectory() as tmp:
             cfg, limits, index, cp, out = self._ctx(tmp)

--- a/scripts/scraper_mef/tests/test_runner_gate2.py
+++ b/scripts/scraper_mef/tests/test_runner_gate2.py
@@ -1,0 +1,302 @@
+"""Test bloccanti Gate 2 / PR #6: max attempts, resume, mismatch, 403/429, duplicati."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT.parent))
+
+from scraper_mef.cache import SkipIndex  # noqa: E402
+from scraper_mef.checkpoint import Checkpoint  # noqa: E402
+from scraper_mef.client import MefBlockedError, MefHttpError  # noqa: E402
+from scraper_mef.config import Config  # noqa: E402
+from scraper_mef.download import make_minimal_pdf  # noqa: E402
+from scraper_mef.limits import RunLimits  # noqa: E402
+from scraper_mef.metrics import Metrics  # noqa: E402
+from scraper_mef.parse import PortalRow  # noqa: E402
+from scraper_mef.runner import process_rows  # noqa: E402
+
+
+def _rows(*specs: tuple[str, str, str, str]) -> list[PortalRow]:
+    out = []
+    for i, (tipo, num, anno, corte) in enumerate(specs):
+        out.append(
+            PortalRow(
+                tipo=tipo,
+                numero=num,
+                anno=anno,
+                corte=corte,
+                href=f"/ricerca/dettaglio/{num}",
+                row_index=i,
+            )
+        )
+    return out
+
+
+class TestRunnerGate2(unittest.TestCase):
+    def _ctx(self, tmp: str):
+        out = Path(tmp) / "out"
+        out.mkdir()
+        cfg = Config()
+        cfg.tmp_dir = Path(tmp) / "tmp"
+        cfg.tmp_dir.mkdir()
+        cfg.min_pdf_bytes = 1000
+        cfg.max_pdf_bytes = 5_000_000
+        cfg.upload_enabled = False
+        # delay zero per test veloci
+        limits = RunLimits(
+            max_download_concurrency=1,
+            delay_min=0.0,
+            delay_max=0.0,
+            page_delay=0.0,
+        )
+        index = SkipIndex(
+            output_dir=out,
+            server_cache_files=[],
+            min_pdf_bytes=cfg.min_pdf_bytes,
+            max_pdf_bytes=cfg.max_pdf_bytes,
+        )
+        cp = Checkpoint(Path(tmp) / "cp.json")
+        return cfg, limits, index, cp, out
+
+    def test_max_counts_failed_attempts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(
+                ("Sentenza", "1", "2026", "CGT 2° Lombardia"),
+                ("Sentenza", "2", "2026", "CGT 2° Lombardia"),
+                ("Sentenza", "3", "2026", "CGT 2° Lombardia"),
+            )
+            calls = {"n": 0}
+
+            def fetch(row: PortalRow):
+                calls["n"] += 1
+                raise RuntimeError("boom simulato")
+
+            metrics = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=2,
+                page_number=1,
+                fetch_pdf=fetch,
+                require_detail_meta=False,
+                resume=False,
+            )
+            self.assertEqual(metrics.attempts, 2)
+            self.assertEqual(calls["n"], 2)
+            self.assertEqual(metrics.downloaded, 0)
+            self.assertEqual(metrics.errors, 2)
+
+    def test_resume_skips_processed_and_row_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(
+                ("Sentenza", "10", "2026", "CGT 2° Lombardia"),
+                ("Sentenza", "11", "2026", "CGT 2° Lombardia"),
+            )
+
+            def fetch_ok(row: PortalRow):
+                return make_minimal_pdf(1200), row.to_meta()
+
+            metrics = Metrics()
+            process_rows(
+                rows[:1],
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=1,
+                page_number=1,
+                fetch_pdf=fetch_ok,
+                resume=False,
+            )
+            self.assertEqual(metrics.downloaded, 1)
+
+            # seconda run: resume, non deve ridscaricare
+            metrics2 = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics2,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=5,
+                page_number=1,
+                fetch_pdf=fetch_ok,
+                resume=True,
+            )
+            self.assertGreaterEqual(metrics2.skipped_checkpoint, 1)
+            # secondo doc scaricato una volta
+            self.assertEqual(metrics2.downloaded, 1)
+            self.assertEqual(metrics2.attempts, 1)
+
+    def test_detail_mismatch_counts_as_attempt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(("Sentenza", "1205", "2026", "CGT 2° Lombardia"))
+
+            def fetch_mismatch(row: PortalRow):
+                wrong = row.to_meta()
+                wrong = dict(wrong)
+                wrong["numero"] = "999"
+                wrong["nomeBase"] = "Sentenza_V70_999_2026"
+                wrong["nomeFile"] = "Sentenza_V70_999_2026.pdf"
+                return make_minimal_pdf(1200), wrong
+
+            metrics = Metrics()
+            items = process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=1,
+                page_number=1,
+                fetch_pdf=fetch_mismatch,
+                require_detail_meta=True,
+                resume=False,
+            )
+            self.assertEqual(metrics.attempts, 1)
+            self.assertEqual(metrics.downloaded, 0)
+            self.assertEqual(items[0]["action"], "download_error")
+            self.assertIn("disallineati", items[0]["error"])
+
+    def test_blocked_403_stops(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(
+                ("Sentenza", "1", "2026", "CGT 2° Lombardia"),
+                ("Sentenza", "2", "2026", "CGT 2° Lombardia"),
+            )
+
+            def fetch_403(row: PortalRow):
+                raise MefBlockedError(403, "forbidden")
+
+            metrics = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=5,
+                page_number=1,
+                fetch_pdf=fetch_403,
+                resume=False,
+            )
+            self.assertEqual(metrics.blocked, 1)
+            self.assertEqual(metrics.attempts, 1)
+            self.assertEqual(cp.data["status"], "blocked")
+
+    def test_http_500_counts_attempt_continues(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(
+                ("Sentenza", "1", "2026", "CGT 2° Lombardia"),
+                ("Sentenza", "2", "2026", "CGT 2° Lombardia"),
+            )
+            state = {"n": 0}
+
+            def fetch(row: PortalRow):
+                state["n"] += 1
+                if state["n"] == 1:
+                    raise MefHttpError(500, "server")
+                return make_minimal_pdf(1200), row.to_meta()
+
+            metrics = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=metrics,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=2,
+                page_number=1,
+                fetch_pdf=fetch,
+                resume=False,
+            )
+            self.assertEqual(metrics.attempts, 2)
+            self.assertEqual(metrics.downloaded, 1)
+            self.assertEqual(metrics.errors, 1)
+
+    def test_duplicate_idempotent_second_pass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg, limits, index, cp, out = self._ctx(tmp)
+            rows = _rows(("Sentenza", "50", "2026", "CGT 2° Lombardia"))
+
+            def fetch(row: PortalRow):
+                return make_minimal_pdf(1200), row.to_meta()
+
+            m1 = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=m1,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=1,
+                page_number=1,
+                fetch_pdf=fetch,
+                resume=False,
+            )
+            # status completed → reset row index ma keep processed
+            cp.data["status"] = "completed"
+            cp.data["last_row_index"] = 0
+            cp.save()
+
+            m2 = Metrics()
+            process_rows(
+                rows,
+                index=index,
+                checkpoint=cp,
+                metrics=m2,
+                limits=limits,
+                cfg=cfg,
+                output_dir=out,
+                max_attempts=1,
+                page_number=1,
+                fetch_pdf=fetch,
+                resume=True,
+            )
+            self.assertEqual(m2.downloaded, 0)
+            self.assertEqual(m2.attempts, 0)
+            # skip_local oppure skip_checkpoint
+            self.assertGreaterEqual(m2.skipped_local + m2.skipped_checkpoint, 1)
+
+    def test_no_hardcoded_developer_paths_in_config(self):
+        """Default output/cache devono stare sotto il modulo, non path assoluti personali."""
+        import scraper_mef.config as cfgmod
+
+        # garanzia: non esistono più costanti assolute tipiche del PC sviluppatore
+        self.assertFalse(hasattr(cfgmod, "DEFAULT_MATTEO_SGAI"))
+        self.assertFalse(hasattr(cfgmod, "DEFAULT_SERVER_CACHES"))
+        cfg = Config()
+        self.assertEqual(cfg.output_dir, cfgmod.ROOT / "downloads_out")
+        caches = cfg.default_server_caches()
+        self.assertEqual(len(caches), 1)
+        self.assertEqual(caches[0], cfgmod.DEFAULT_CACHE_KEYS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/scraper_mef/upload.py
+++ b/scripts/scraper_mef/upload.py
@@ -1,0 +1,16 @@
+"""Upload verso SGAI — disabilitato fino a Gate 2 / PILOTA AUTORIZZATO."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class UploadDisabledError(RuntimeError):
+    pass
+
+
+def enqueue_upload(path: Path, *, enabled: bool = False) -> dict:
+    if not enabled:
+        raise UploadDisabledError(
+            "Upload SGAI disabilitato (MEF_SCRAPER_UPLOAD!=1 / Gate 2 non aperto)"
+        )
+    raise NotImplementedError("Upload reale non implementato in Fase 2 stub")


### PR DESCRIPTION
>> ## Summary
>> - Modulo ``scripts/scraper_mef/``: parse, mappa corti, skip A/B/C, dry-run/probe/run
>> - ``run --simulate`` e ``run --live`` (CDP); upload disabilitato
>> - Limiti: concurrency 1, delay download, checkpoint
>>
>> ## Test plan
>> - [ ] ``python -m scripts.scraper_mef dry-run``
>> - [ ] ``python -m scripts.scraper_mef run --max 1``
>> - [ ] ``python -m scripts.scraper_mef run --live --max 1 --cdp http://127.0.0.1:9222``
>> - [ ] unittest parse/cache/checkpoint